### PR TITLE
feat: governance + security batch (MS-11/12)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Pre-commit hook: prevent secrets from being committed
+# Scans staged files for common secret patterns
+#
+# Covers:
+#   - OpenRouter API keys (sk-or-)
+#   - JWT/HA long-lived access tokens (eyJ header.payload.signature)
+#   - Bearer tokens hardcoded in source
+#   - Hardcoded API key assignments
+#
+# Compatible: macOS (BSD grep) and Linux (GNU grep)
+#   - Uses 'grep ^+' (literal) not 'grep -E ^\+' to avoid BSD grep issue
+#   - Uses only POSIX ERE character classes (no {n,} quantifiers on macOS)
+#
+# Install: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+FOUND_SECRETS=0
+
+# Get list of staged files (Added, Copied, Modified — not Deleted)
+STAGED_FILES=$(git diff --cached --diff-filter=ACM --name-only 2>/dev/null)
+
+if [[ -z "$STAGED_FILES" ]]; then
+    exit 0
+fi
+
+# Extract added lines from staged diff of a file.
+# Uses literal 'grep ^+' (not 'grep -E ^\+') for macOS BSD grep compatibility.
+get_staged_additions() {
+    local file="$1"
+    git diff --cached -- "$file" | grep '^+' | grep -v '^+++'
+}
+
+check_pattern() {
+    local description="$1"
+    local pattern="$2"
+    local exclude_pattern="${3:-}"
+
+    while IFS= read -r file; do
+        # Skip example/placeholder files
+        case "$file" in
+            *.example|*example.*|*.example.*) continue ;;
+        esac
+        # Skip .env files (expected to contain secrets, must be gitignored)
+        case "$file" in
+            .env|.env.*|*/.env|*/.env.*) continue ;;
+        esac
+
+        local additions
+        additions=$(get_staged_additions "$file" 2>/dev/null || true)
+        [[ -z "$additions" ]] && continue
+
+        local matches
+        matches=$(echo "$additions" | grep -E "$pattern" || true)
+        [[ -z "$matches" ]] && continue
+
+        if [[ -n "$exclude_pattern" ]]; then
+            matches=$(echo "$matches" | grep -vE "$exclude_pattern" || true)
+        fi
+
+        if [[ -n "$matches" ]]; then
+            echo -e "${RED}SECRET DETECTED${NC}: $description"
+            echo -e "  File: ${YELLOW}$file${NC}"
+            FOUND_SECRETS=1
+        fi
+    done <<< "$STAGED_FILES"
+}
+
+# Pattern 1: OpenRouter API keys (sk-or- prefix)
+# Real keys: sk-or-v1-abcdef1234567890abcdef...
+check_pattern \
+    "OpenRouter API key (sk-or-)" \
+    'sk-or-[a-zA-Z0-9_-]+' \
+    'sk-or-\.\.\.|sk-or-<|sk-or-YOUR|#.*sk-or-'
+
+# Pattern 2: JWT tokens with 3-part structure (header.payload.signature)
+# HA long-lived access tokens are JWTs: eyJ<base64url>.<base64url>.<base64url>
+# Uses [.] instead of \. for macOS ERE compatibility
+check_pattern \
+    "JWT / HA long-lived access token (eyJ<header>.<payload>.<signature>)" \
+    'eyJ[a-zA-Z0-9_-]+[.][a-zA-Z0-9_-]+[.][a-zA-Z0-9_-]+' \
+    'eyJ\.\.\.|eyJ<|#.*eyJ|example.*eyJ|mock.*eyJ|fake.*eyJ|test.*eyJ'
+
+# Pattern 3: Bearer token with actual JWT value (not an env var reference)
+check_pattern \
+    "Hardcoded Bearer token (not from env var)" \
+    'Bearer eyJ[a-zA-Z0-9_-]+[.][a-zA-Z0-9_-]+' \
+    'Bearer \$|Bearer \$\{|\.\.\.|<TOKEN>|YOUR_TOKEN|example|mock|fake'
+
+# Pattern 4: Direct assignment of OpenRouter key (not via os.environ)
+check_pattern \
+    "Hardcoded OpenRouter key assignment" \
+    'OPENROUTER_API_KEY[[:space:]]*=[[:space:]]*sk-or-[a-zA-Z0-9_-]+' \
+    'os[.]environ|os[.]getenv|getenv|example|placeholder'
+
+if [[ $FOUND_SECRETS -eq 1 ]]; then
+    echo ""
+    echo -e "${RED}COMMIT BLOCKED${NC}: Potential secrets detected in staged files."
+    echo ""
+    echo "To fix:"
+    echo "  1. Remove the secret value from the file"
+    echo "  2. Use environment variables: os.environ.get('TOKEN_NAME')"
+    echo "  3. Store secrets in .env (which is gitignored)"
+    echo "  4. If this is a confirmed false positive: git commit --no-verify"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ htmlcov/
 .ruff_cache/
 .mypy_cache/
 autotune/data/*.json
+
+# ===== Secrets & auth =====
+.env
+.env.*
+!.env.example
+*.key
+secrets.yaml
+ha-api.md

--- a/custom_components/victron_mpc/__init__.py
+++ b/custom_components/victron_mpc/__init__.py
@@ -29,6 +29,7 @@ from .coordinator import VictronMPCCoordinator
 
 SERVICE_EMERGENCY_STOP = "emergency_stop"
 SERVICE_EMERGENCY_RESUME = "emergency_resume"
+SERVICE_RECORD_FEEDBACK = "record_feedback"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -80,6 +81,7 @@ async def async_unload_entry(
     # Remove services when the last entry is unloaded
     hass.services.async_remove(DOMAIN, SERVICE_EMERGENCY_STOP)
     hass.services.async_remove(DOMAIN, SERVICE_EMERGENCY_RESUME)
+    hass.services.async_remove(DOMAIN, SERVICE_RECORD_FEEDBACK)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
@@ -109,7 +111,29 @@ def _register_services(
         hass.services.async_register(
             DOMAIN, SERVICE_EMERGENCY_RESUME, _handle_emergency_resume, schema=vol.Schema({}),
         )
-    LOGGER.info("Registered services: %s.%s, %s.%s", DOMAIN, SERVICE_EMERGENCY_STOP, DOMAIN, SERVICE_EMERGENCY_RESUME)
+
+    async def _handle_record_feedback(call: ServiceCall) -> None:
+        """Handle record_feedback service call."""
+        await coordinator.record_human_feedback(
+            human_verdict=call.data["human_verdict"],
+            human_reasoning=call.data["human_reasoning"],
+            uat_verdict=call.data.get("uat_verdict", ""),
+            genai_verdict=call.data.get("genai_verdict", ""),
+        )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_RECORD_FEEDBACK):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_RECORD_FEEDBACK,
+            _handle_record_feedback,
+            schema=vol.Schema({
+                vol.Required("human_verdict"): vol.In(["agree", "disagree", "override"]),
+                vol.Required("human_reasoning"): str,
+                vol.Optional("uat_verdict", default=""): str,
+                vol.Optional("genai_verdict", default=""): str,
+            }),
+        )
+    LOGGER.info("Registered services: %s.%s, %s.%s, %s.%s", DOMAIN, SERVICE_EMERGENCY_STOP, DOMAIN, SERVICE_EMERGENCY_RESUME, DOMAIN, SERVICE_RECORD_FEEDBACK)
 
 
 async def _async_update_options(

--- a/custom_components/victron_mpc/coordinator.py
+++ b/custom_components/victron_mpc/coordinator.py
@@ -1912,6 +1912,7 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "solar_used_next_kw": round(result.solar_used_schedule_kw[0], 2) if result.solar_used_schedule_kw else 0,
                 "solar_forecast_kwh_today": solar_forecast_kwh,
                 "weather_confidence": forecasts.get("weather_confidence", 1.0),
+                "intent": result.intent,
                 **soc_lookahead,
             },
             # Scalar sensors

--- a/custom_components/victron_mpc/coordinator.py
+++ b/custom_components/victron_mpc/coordinator.py
@@ -48,6 +48,7 @@ from .forecast_accuracy import compute_forecast_accuracy
 from .forecasts import ForecastBuilder
 from .genai_monitor import (
     GENAI_CYCLE_INTERVAL,
+    PROMPT_VERSION,
     build_strategic_snapshot,
     run_deterministic_checks,
     run_genai_health_check,
@@ -208,6 +209,14 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Audit log — every register write with full decision context (#56)
         self._audit_log: list[dict[str, Any]] = []
         self._audit_log_max = 2016  # 7 days × 288 cycles/day
+
+        # Human feedback log — captures human verdicts vs UAT/GenAI (#60)
+        self._human_feedback_log: list[dict[str, Any]] = []
+        self._human_feedback_log_max = 200
+
+        # Modbus write audit log — every register write with source tracking (#65)
+        self._modbus_write_log: list[dict[str, Any]] = []
+        self._modbus_write_log_max = 2016  # 7 days × 288 cycles/day
 
     async def _async_setup(self) -> None:
         """One-time setup called during first refresh (HA 2024.8+).
@@ -737,6 +746,10 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     int(forecasts.get("current_solar_w", 0)),
                     int(forecasts.get("current_load_w", 0)),
                     extra.get("grid_import_w", 0),
+                    details="; ".join(r["reason"] for r in deterministic_results),
+                    deterministic_checks=[r["check"] for r in deterministic_results],
+                    amber_band=(forecasts.get("price_bands") or ["unknown"])[0],
+                    weather=extra.get("weather", "unknown"),
                 )
                 LOGGER.warning("Deterministic RED: %s", first_red["reason"])
                 if self._genai_consecutive_red >= 2:
@@ -795,6 +808,10 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         int(forecasts.get("current_solar_w", 0)),
                         int(forecasts.get("current_load_w", 0)),
                         extra.get("grid_import_w", 0),
+                        details=genai_result.get("details", ""),
+                        deterministic_checks=[],
+                        amber_band=(forecasts.get("price_bands") or ["unknown"])[0],
+                        weather=extra.get("weather", "unknown"),
                     )
                     LOGGER.info(
                         "GenAI strategic: %s -- %s",
@@ -1011,8 +1028,29 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         solar_w: int,
         load_w: int,
         grid_import_w: int,
+        *,
+        details: str = "",
+        deterministic_checks: list[str] | None = None,
+        amber_band: str = "unknown",
+        weather: str = "unknown",
     ) -> None:
-        """Append health check result to rolling history buffer."""
+        """Append health check result to rolling history buffer.
+
+        Args:
+            source: Origin of the check ("deterministic" or "genai").
+            status: Overall status string ("GREEN", "YELLOW", "RED", or "?").
+            summary: Short human-readable summary of the result.
+            soc_pct: Battery state-of-charge at time of check.
+            mode: Current MPC operating mode (e.g. "discharge", "grid_charge").
+            buy_price: Current Amber buy price in $/kWh.
+            solar_w: Current solar generation in watts.
+            load_w: Current house load in watts.
+            grid_import_w: Current grid import in watts.
+            details: Full reasoning text from GenAI or deterministic details.
+            deterministic_checks: Names of checks that returned RED; empty if all GREEN.
+            amber_band: Current Amber price band descriptor (e.g. "low", "spike").
+            weather: Current weather condition string.
+        """
         # Deduplicate: skip if same as last entry
         if self._genai_history:
             last = self._genai_history[-1]
@@ -1024,6 +1062,11 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "source": source,
             "status": status,
             "summary": summary,
+            "details": details,
+            "prompt_version": PROMPT_VERSION,
+            "deterministic_checks": deterministic_checks if deterministic_checks is not None else [],
+            "amber_band": amber_band,
+            "weather": weather,
             "readings": {
                 "soc_pct": round(soc_pct, 1),
                 "mode": mode,
@@ -1035,6 +1078,130 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         })
         if len(self._genai_history) > self._genai_history_max:
             self._genai_history = self._genai_history[-self._genai_history_max:]
+
+    async def record_human_feedback(
+        self,
+        human_verdict: str,
+        human_reasoning: str,
+        uat_verdict: str = "",
+        genai_verdict: str = "",
+    ) -> None:
+        """Record a human feedback entry capturing human vs system verdicts.
+
+        Called via the ``record_feedback`` HA service when the human agrees,
+        disagrees, or overrides the UAT or GenAI assessment.
+
+        Args:
+            human_verdict: One of "agree", "disagree", or "override".
+            human_reasoning: Free-text explanation of the human's decision.
+            uat_verdict: The UAT assessment verdict at time of feedback (optional).
+            genai_verdict: The GenAI assessment verdict at time of feedback (optional).
+        """
+        # Build a resilient system snapshot — each state read uses .get() with
+        # safe defaults so the method works even in tests without HA.
+        soc_pct: float = 0.0
+        mode: str = "unknown"
+        buy_price: float = 0.0
+        solar_w: int = 0
+        load_w: int = 0
+        grid_import_w: int = 0
+        amber_band: str = "unknown"
+        weather: str = "unknown"
+
+        try:
+            data = self.data or {}
+            soc_pct = float(data.get("battery_plan") or 0.0)
+            mode = str(data.get("decision") or "unknown")
+            if isinstance(data.get("decision"), dict):
+                mode = data["decision"].get("state", "unknown")
+            buy_price = float(data.get("buy_price") or 0.0)
+            solar_w = int(data.get("solar_input_w") or 0)
+            load_w = int(data.get("load_input_w") or 0)
+        except (TypeError, ValueError):
+            pass
+
+        try:
+            forecasts = getattr(self, "_last_forecasts", {}) or {}
+            bands = forecasts.get("price_bands") or []
+            if bands:
+                amber_band = str(bands[0])
+            weather = str(forecasts.get("weather_condition", "unknown"))
+        except (TypeError, AttributeError):
+            pass
+
+        try:
+            grid_state = self.hass.states.get("sensor.victron_grid_power")
+            if grid_state and grid_state.state not in ("unknown", "unavailable"):
+                grid_import_w = max(0, int(float(grid_state.state)))
+        except (TypeError, ValueError, AttributeError):
+            pass
+
+        # Current GenAI status from last result
+        genai_status = self._last_genai_result.get("status", "") if self._last_genai_result else ""
+
+        entry: dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "human_verdict": human_verdict,
+            "human_reasoning": human_reasoning,
+            "uat_verdict": uat_verdict,
+            "genai_verdict": genai_verdict,
+            "genai_status": genai_status,
+            "prompt_version": PROMPT_VERSION,
+            "readings": {
+                "soc_pct": round(soc_pct, 1),
+                "mode": mode,
+                "buy_price": round(buy_price, 4),
+                "solar_w": solar_w,
+                "load_w": load_w,
+                "grid_import_w": grid_import_w,
+                "amber_band": amber_band,
+                "weather": weather,
+            },
+        }
+
+        self._human_feedback_log.append(entry)
+        if len(self._human_feedback_log) > self._human_feedback_log_max:
+            self._human_feedback_log = self._human_feedback_log[-self._human_feedback_log_max:]
+
+        LOGGER.info(
+            "Human feedback recorded: verdict=%s, uat=%s, genai=%s — %s",
+            human_verdict, uat_verdict, genai_verdict, human_reasoning,
+        )
+
+    def _compute_disagreement_stats(self) -> dict[str, Any]:
+        """Compute disagreement rate statistics from the human feedback log.
+
+        Returns:
+            Dict with total_feedback, disagree_count, agree_count,
+            disagreement_rate (0.0-1.0), and recent_7d sub-dict with the
+            same fields filtered to the last 7 days.
+        """
+        log = self._human_feedback_log
+        total = len(log)
+        disagree_count = sum(1 for e in log if e.get("human_verdict") == "disagree")
+        agree_count = sum(1 for e in log if e.get("human_verdict") == "agree")
+        rate = round(disagree_count / total, 4) if total > 0 else 0.0
+
+        # Recent 7-day window
+        cutoff = (datetime.now() - timedelta(days=7)).isoformat(timespec="seconds")
+        recent = [e for e in log if e.get("timestamp", "") >= cutoff]
+        recent_total = len(recent)
+        recent_disagree = sum(1 for e in recent if e.get("human_verdict") == "disagree")
+        recent_agree = sum(1 for e in recent if e.get("human_verdict") == "agree")
+        recent_rate = round(recent_disagree / recent_total, 4) if recent_total > 0 else 0.0
+
+        return {
+            "total_feedback": total,
+            "disagree_count": disagree_count,
+            "agree_count": agree_count,
+            "disagreement_rate": rate,
+            "recent_7d": {
+                "total_feedback": recent_total,
+                "disagree_count": recent_disagree,
+                "agree_count": recent_agree,
+                "disagreement_rate": recent_rate,
+            },
+        }
 
     def _get_r2901_readback(self) -> float:
         """Read R2901 from the Modbus sensor."""
@@ -1524,6 +1691,68 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # Sensor data builder
     # ------------------------------------------------------------------
 
+    def _compute_prompt_version_stats(self) -> dict[str, dict[str, Any]]:
+        """Compute per-prompt-version statistics from the GenAI history buffer.
+
+        Groups genai_history entries by their ``prompt_version`` field and
+        produces aggregate statistics for each version.  This enables
+        data-driven prompt calibration — callers can compare yellow_rate
+        across versions to measure whether a new prompt reduces false
+        positives.
+
+        Returns:
+            Dict keyed by version string (e.g. ``"v4"``).  Each value is a
+            dict with the following fields:
+
+            - ``total_assessments`` (int): Number of history entries for the
+              version.
+            - ``yellow_count`` (int): Entries whose ``status`` is ``"YELLOW"``.
+            - ``green_count`` (int): Entries whose ``status`` is ``"GREEN"``.
+            - ``error_count`` (int): Entries with status ``"ERROR"``,
+              ``"SKIP"``, or ``"?"`` (non-actionable results).
+            - ``yellow_rate`` (float): ``yellow_count / total_assessments``,
+              or 0.0 when there are no entries.
+            - ``first_seen`` (str): ISO 8601 timestamp of the earliest entry
+              for this version.
+            - ``last_seen`` (str): ISO 8601 timestamp of the most recent entry
+              for this version.
+        """
+        stats: dict[str, dict[str, Any]] = {}
+        for entry in self._genai_history:
+            version = entry.get("prompt_version", "unknown")
+            if version not in stats:
+                stats[version] = {
+                    "total_assessments": 0,
+                    "yellow_count": 0,
+                    "green_count": 0,
+                    "error_count": 0,
+                    "yellow_rate": 0.0,
+                    "first_seen": entry.get("timestamp", ""),
+                    "last_seen": entry.get("timestamp", ""),
+                }
+            bucket = stats[version]
+            bucket["total_assessments"] += 1
+            status = entry.get("status", "")
+            if status == "YELLOW":
+                bucket["yellow_count"] += 1
+            elif status == "GREEN":
+                bucket["green_count"] += 1
+            elif status in ("ERROR", "SKIP", "?"):
+                bucket["error_count"] += 1
+            ts = entry.get("timestamp", "")
+            if ts:
+                if not bucket["first_seen"] or ts < bucket["first_seen"]:
+                    bucket["first_seen"] = ts
+                if not bucket["last_seen"] or ts > bucket["last_seen"]:
+                    bucket["last_seen"] = ts
+
+        # Compute yellow_rate as a final pass to avoid repeated division
+        for bucket in stats.values():
+            total = bucket["total_assessments"]
+            bucket["yellow_rate"] = round(bucket["yellow_count"] / total, 4) if total > 0 else 0.0
+
+        return stats
+
     def _build_sensor_data(
         self,
         *,
@@ -1766,6 +1995,34 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "state": len(self._audit_log),
                 "entries": self._audit_log[-50:],
             },
+            # GenAI audit log — full history for analysis (#57)
+            # version_stats and current_version added for #61 prompt calibration
+            "genai_audit_log": {
+                "state": len(self._genai_history),
+                "entries": self._genai_history,
+                "false_positive_count": sum(
+                    1 for e in self._genai_history if e.get("status") == "YELLOW"
+                ),
+                "prompt_version": PROMPT_VERSION,
+                "current_version": PROMPT_VERSION,
+                "version_stats": self._compute_prompt_version_stats(),
+            },
+            # Human feedback log — captures human vs UAT/GenAI verdicts (#60)
+            "human_feedback": {
+                "state": len(self._human_feedback_log),
+                "entries": self._human_feedback_log[-50:],
+                "disagreement_stats": self._compute_disagreement_stats(),
+                "total_entries": len(self._human_feedback_log),
+            },
+            # Modbus write audit log — every register write with source tracking (#65)
+            "modbus_write_log": {
+                "state": len(self._modbus_write_log),
+                "entries": self._modbus_write_log[-50:],
+                "rogue_write_count": sum(
+                    1 for e in self._modbus_write_log if e.get("source") == "unknown_external"
+                ),
+                "total_writes": len(self._modbus_write_log),
+            },
         }
 
     # ------------------------------------------------------------------
@@ -1789,6 +2046,11 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         value = max(100, min(1000, value))  # Clamp to valid range
         previous = self._last_register_value
+
+        # Audit tracking — populated during write/verify loop
+        verified: bool | None = None
+        final_readback: float | None = None
+        persistent_mismatch = False
 
         for attempt in range(2):  # write + 1 retry
             try:
@@ -1819,8 +2081,11 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "R2901 written: %d (was %s), readback unavailable",
                     value, previous,
                 )
+                verified = None
+                final_readback = None
                 break
 
+            final_readback = readback
             # Tolerance: register is SoC% × 10, sensor is SoC%.
             # Accept if within 1% (10 register units).
             expected_pct = value / 10.0
@@ -1829,6 +2094,7 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "R2901 written: %d (was %s), readback %.1f%% — verified",
                     value, previous, readback,
                 )
+                verified = True
                 break
 
             if attempt == 0:
@@ -1838,6 +2104,8 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     value, value / 10.0, readback,
                 )
             else:
+                verified = False
+                persistent_mismatch = True
                 LOGGER.warning(
                     "R2901 READBACK MISMATCH PERSISTENT: wrote %d (%.1f%%) "
                     "but read %.1f%% after retry. Possible BatteryLife "
@@ -1851,6 +2119,41 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._last_register_value = value
         await self._modbus_write_success()
+
+        # Append to Modbus write audit log (#65)
+        log_entry: dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(),
+            "register": REGISTER_ESS_MIN_SOC,
+            "register_name": "ess_min_soc",
+            "value": value,
+            "previous_value": previous,
+            "source": "hacs_mpc",
+            "verified": verified,
+            "readback_value": final_readback,
+            "cycle": getattr(self, "_cycle_count", None),
+            "mode": getattr(self, "_last_mode", None),
+            "reason": "R2901 write — ESS min SoC floor",
+        }
+        self._modbus_write_log.append(log_entry)
+        if len(self._modbus_write_log) > self._modbus_write_log_max:
+            self._modbus_write_log = self._modbus_write_log[-self._modbus_write_log_max:]
+
+        # If persistent mismatch detected, also log a rogue write suspicion entry
+        if persistent_mismatch and final_readback is not None:
+            rogue_entry: dict[str, Any] = {
+                "timestamp": datetime.now().isoformat(),
+                "register": REGISTER_ESS_MIN_SOC,
+                "register_name": "ess_min_soc",
+                "source": "unknown_external",
+                "expected_value": value,
+                "actual_value": int(final_readback * 10),
+                "alert": True,
+                "cycle": getattr(self, "_cycle_count", None),
+                "mode": getattr(self, "_last_mode", None),
+            }
+            self._modbus_write_log.append(rogue_entry)
+            if len(self._modbus_write_log) > self._modbus_write_log_max:
+                self._modbus_write_log = self._modbus_write_log[-self._modbus_write_log_max:]
 
     async def _write_feedin_register(self, value: int) -> None:
         """Write max grid feed-in register (R2706) via Modbus.
@@ -1869,6 +2172,7 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             value = REGISTER_FEEDIN_BLOCK
 
+        previous_feedin = self._last_feedin_value
         try:
             await self.hass.services.async_call(
                 "modbus",
@@ -1883,6 +2187,22 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             LOGGER.info("R2706 written: %d (was %s)", value, self._last_feedin_value)
             self._last_feedin_value = value
             await self._modbus_write_success()
+            # Append to Modbus write audit log (#65)
+            self._modbus_write_log.append({
+                "timestamp": datetime.now().isoformat(),
+                "register": REGISTER_MAX_FEED_IN,
+                "register_name": "max_feed_in",
+                "value": value,
+                "previous_value": previous_feedin,
+                "source": "hacs_mpc",
+                "verified": None,  # No read-back on R2706
+                "readback_value": None,
+                "cycle": getattr(self, "_cycle_count", None),
+                "mode": getattr(self, "_last_mode", None),
+                "reason": "R2706 write — max grid feed-in",
+            })
+            if len(self._modbus_write_log) > self._modbus_write_log_max:
+                self._modbus_write_log = self._modbus_write_log[-self._modbus_write_log_max:]
         except Exception:
             LOGGER.exception("Failed to write R2706=%d", value)
             await self._modbus_write_failure()
@@ -1912,6 +2232,22 @@ class VictronMPCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "value": 12,
                 },
             )
+            # Append to Modbus write audit log (#65)
+            self._modbus_write_log.append({
+                "timestamp": datetime.now().isoformat(),
+                "register": REGISTER_BATTERYLIFE_STATE,
+                "register_name": "batterylife_state",
+                "value": 12,
+                "previous_value": None,  # Not tracked separately
+                "source": "hacs_mpc",
+                "verified": None,  # No read-back on R2900
+                "readback_value": None,
+                "cycle": getattr(self, "_cycle_count", None),
+                "mode": getattr(self, "_last_mode", None),
+                "reason": "R2900 write — disable BatteryLife",
+            })
+            if len(self._modbus_write_log) > self._modbus_write_log_max:
+                self._modbus_write_log = self._modbus_write_log[-self._modbus_write_log_max:]
         except Exception:
             LOGGER.exception("Failed to write R2900=12 (BatteryLife disable)")
 

--- a/custom_components/victron_mpc/genai_monitor.py
+++ b/custom_components/victron_mpc/genai_monitor.py
@@ -26,6 +26,11 @@ _LOGGER = logging.getLogger(__name__)
 # Cycle counter -- GenAI runs every 12th cycle (hourly)
 GENAI_CYCLE_INTERVAL = 12
 
+# Prompt version — incremented each time the SYSTEM_PROMPT is significantly revised.
+# History: v1 initial, v2 add normal-pattern calibration, v3 add false-positive guidance,
+# v4 add phase-by-phase pattern library (current)
+PROMPT_VERSION = "v4"
+
 
 # ---------------------------------------------------------------------------
 # Layer 1: Deterministic checks (every cycle, no LLM)

--- a/custom_components/victron_mpc/genai_monitor.py
+++ b/custom_components/victron_mpc/genai_monitor.py
@@ -29,7 +29,7 @@ GENAI_CYCLE_INTERVAL = 12
 # Prompt version — incremented each time the SYSTEM_PROMPT is significantly revised.
 # History: v1 initial, v2 add normal-pattern calibration, v3 add false-positive guidance,
 # v4 add phase-by-phase pattern library (current)
-PROMPT_VERSION = "v4"
+PROMPT_VERSION = "v5"
 
 
 # ---------------------------------------------------------------------------
@@ -263,14 +263,45 @@ def build_strategic_snapshot(
 
     now = datetime.now()
 
+    # Weather context — critical for understanding solar forecast reliability
+    weather = extra.get("weather", "unknown")
+    cloud_pct = coordinator_data.get("cloud_coverage", {})
+    if isinstance(cloud_pct, dict):
+        cloud_pct = cloud_pct.get("state", "?")
+    weather_confidence = coordinator_data.get("decision", {})
+    if isinstance(weather_confidence, dict):
+        weather_confidence = weather_confidence.get("weather_confidence", "?")
+    else:
+        weather_confidence = "?"
+    current_solar_w = coordinator_data.get("solar_input_w", "?")
+
+    # LP decision intent — why the optimizer chose this mode
+    decision = coordinator_data.get("decision", {})
+    if isinstance(decision, dict):
+        lp_reason = decision.get("reason", "")
+        override_applied = decision.get("override_applied", False)
+        override_reason = decision.get("override_reason", "")
+    else:
+        lp_reason = ""
+        override_applied = False
+        override_reason = ""
+
     lines = [
         f"Time: {now.strftime('%H:%M')} ({now.strftime('%A')})",
         f"Mode: {fields['mode']}",
+        f"LP Reasoning: {lp_reason}" if lp_reason else "LP Reasoning: (not available)",
+        f"Override Active: {override_reason}" if override_applied and override_reason else "",
         f"SoC: {fields['soc_pct']}%",
         f"Buy Price: ${fields['buy_price']}/kWh" if fields["buy_price"] is not None else "Buy Price: ?",
         f"Amber Band: {fields['amber_band']}" if fields["amber_band"] else "Amber Band: ?",
+        f"Weather: {weather}",
+        f"Cloud Coverage: {cloud_pct}%",
+        f"Weather Confidence Factor: {weather_confidence} (1.0=clear, 0.5=rain)",
+        f"Current Solar Output: {current_solar_w}W",
         f"Solar Forecast Remaining Today: {solar_forecast} kWh",
     ]
+    # Remove empty lines (e.g. when no override)
+    lines = [l for l in lines if l]
 
     if trajectory_str:
         lines.append(f"Planned trajectory (next 8h): {trajectory_str}")
@@ -396,6 +427,13 @@ and Amber Electric wholesale pricing.
 All operational checks have PASSED — registers, power flows, and safety conditions \
 are verified by deterministic monitors. Your job is ONLY strategic review.
 
+The snapshot includes "LP Reasoning" — this is the optimizer's own explanation for \
+its current mode choice. The LP has full 24h price forecasts, weather-adjusted solar \
+forecasts, and load predictions. It has MORE information than you do. \
+Your role is to spot cases where the LP's reasoning is INCONSISTENT with the data \
+shown (e.g. LP says "solar charging" but solar is 0W), NOT to second-guess the LP's \
+cost optimization when its reasoning is coherent with conditions.
+
 ## NORMAL DAILY PATTERN (calibrated from production data)
 
 These are EXPECTED behaviors — do NOT flag as YELLOW:
@@ -423,6 +461,15 @@ the LP buys cheap grid now to avoid higher prices overnight. Do NOT flag this.
 Phase 6 — Late Evening (21:00-22:00): Prices drop, discharge slows. \
 SoC may drop to 30-40% before overnight hold kicks in.
 
+## CRITICAL: Weather overrides solar expectations
+
+The snapshot includes Weather, Cloud Coverage %, and Weather Confidence Factor. \
+On rainy days (confidence 0.5) or overcast days (confidence 0.7), solar output is \
+drastically reduced. The LP knows this and adjusts accordingly. \
+If weather is "rainy" or cloud > 90%, grid_charge is almost certainly correct — \
+the LP is compensating for missing solar. Do NOT flag grid_charge as "premature" \
+or "wasting solar" when weather confidence is low. The solar simply will not arrive.
+
 ## CRITICAL: Amber band overrides time-of-day assumptions
 
 Wholesale pricing is volatile — the Amber Band in the snapshot ALWAYS takes precedence \
@@ -445,6 +492,8 @@ high/spike at ANY hour: discharge is expected. Grid_charge during high/spike IS 
 - SoC only reaching 75% on a cloudy day — system adapts, not a failure
 - Gentle overnight SoC decline — inverter efficiency losses, normal physics
 - Grid_charge during evening when Amber band is very_low or extremely_low — LP is buying cheap
+- Grid_charge on rainy/overcast days (confidence < 0.8) — LP compensates for missing solar
+- Grid_charge when current solar output < 500W and cloud > 80% — solar is physically unavailable
 
 Your default answer is GREEN. The system is well-tuned and operates correctly \
 the vast majority of the time. Return GREEN unless you can identify something \

--- a/custom_components/victron_mpc/genai_monitor.py
+++ b/custom_components/victron_mpc/genai_monitor.py
@@ -275,22 +275,43 @@ def build_strategic_snapshot(
         weather_confidence = "?"
     current_solar_w = coordinator_data.get("solar_input_w", "?")
 
-    # LP decision intent — why the optimizer chose this mode
+    # LP structured intent — the optimizer's reasoning chain
     decision = coordinator_data.get("decision", {})
     if isinstance(decision, dict):
-        lp_reason = decision.get("reason", "")
+        intent = decision.get("intent", {})
         override_applied = decision.get("override_applied", False)
         override_reason = decision.get("override_reason", "")
     else:
-        lp_reason = ""
+        intent = {}
         override_applied = False
         override_reason = ""
 
+    # Format intent for GenAI
+    intent_lines = []
+    if intent:
+        intent_lines.append(f"LP Action: {intent.get('action', '?')}")
+        intent_lines.append(f"LP Reasoning: {intent.get('why', '?')}")
+        assumptions = intent.get("key_assumptions", {})
+        if assumptions:
+            intent_lines.append("LP Key Assumptions:")
+            for k, v in assumptions.items():
+                intent_lines.append(f"  {k}: {v}")
+        outcomes = intent.get("expected_outcomes", {})
+        if outcomes:
+            intent_lines.append("LP Expected Outcomes:")
+            for k, v in outcomes.items():
+                if v is not None:
+                    intent_lines.append(f"  {k}: {v}")
+        constraints = intent.get("constraints_active", {})
+        active = [k for k, v in constraints.items() if v]
+        if active:
+            intent_lines.append(f"Active Constraints: {', '.join(active)}")
+    if override_applied and override_reason:
+        intent_lines.append(f"Override Active: {override_reason}")
+
     lines = [
+        "== OBSERVED STATE ==",
         f"Time: {now.strftime('%H:%M')} ({now.strftime('%A')})",
-        f"Mode: {fields['mode']}",
-        f"LP Reasoning: {lp_reason}" if lp_reason else "LP Reasoning: (not available)",
-        f"Override Active: {override_reason}" if override_applied and override_reason else "",
         f"SoC: {fields['soc_pct']}%",
         f"Buy Price: ${fields['buy_price']}/kWh" if fields["buy_price"] is not None else "Buy Price: ?",
         f"Amber Band: {fields['amber_band']}" if fields["amber_band"] else "Amber Band: ?",
@@ -299,9 +320,12 @@ def build_strategic_snapshot(
         f"Weather Confidence Factor: {weather_confidence} (1.0=clear, 0.5=rain)",
         f"Current Solar Output: {current_solar_w}W",
         f"Solar Forecast Remaining Today: {solar_forecast} kWh",
+        "",
+        "== LP STATED INTENT ==",
+        *intent_lines,
     ]
-    # Remove empty lines (e.g. when no override)
-    lines = [l for l in lines if l]
+    # Remove empty lines except the separator
+    lines = [l for l in lines if l or l == ""]
 
     if trajectory_str:
         lines.append(f"Planned trajectory (next 8h): {trajectory_str}")
@@ -421,90 +445,62 @@ def build_health_snapshot(
 
 
 SYSTEM_PROMPT = """\
-You are a strategic advisor for a home battery system with Victron ESS \
-and Amber Electric wholesale pricing.
+You are an alignment auditor for a home battery LP optimizer (Victron ESS + Amber \
+Electric wholesale pricing).
 
-All operational checks have PASSED — registers, power flows, and safety conditions \
-are verified by deterministic monitors. Your job is ONLY strategic review.
+All operational checks have PASSED. Deterministic monitors handle safety. \
+Your SOLE job is to validate that the LP optimizer's STATED INTENT aligns with \
+OBSERVED REALITY.
 
-The snapshot includes "LP Reasoning" — this is the optimizer's own explanation for \
-its current mode choice. The LP has full 24h price forecasts, weather-adjusted solar \
-forecasts, and load predictions. It has MORE information than you do. \
-Your role is to spot cases where the LP's reasoning is INCONSISTENT with the data \
-shown (e.g. LP says "solar charging" but solar is 0W), NOT to second-guess the LP's \
-cost optimization when its reasoning is coherent with conditions.
+## YOUR ROLE: Intent-Execution Alignment
 
-## NORMAL DAILY PATTERN (calibrated from production data)
+The snapshot has two sections:
+1. **OBSERVED STATE** — what sensors actually show (SoC, weather, solar, prices)
+2. **LP STATED INTENT** — the optimizer's reasoning: what it chose, why, its \
+   key assumptions, and expected outcomes
 
-These are EXPECTED behaviors — do NOT flag as YELLOW:
+Your job: check whether the LP's stated assumptions match observed reality. \
+If they align → GREEN. If they contradict → YELLOW.
 
-Phase 1 — Overnight (22:00-06:00): SoC drifts from 40-55% down to 30-35%. \
-Grid import 400-800W is NORMAL (battery at floor, grid serves house load). \
-Mode: hold or gentle discharge. This is not an emergency.
+## ALIGNMENT CHECKS (in priority order)
 
-Phase 2 — Shaded Morning (06:00-11:00): SoC 30-38%, solar 0-500W (trees block panels). \
-Grid import 600-1200W is NORMAL. Battery may discharge slightly to supplement solar. \
-Low solar before 11am is physical shading, not a forecast error.
+1. **Assumption check**: Do the LP's "key_assumptions" match observed state?
+   - LP assumes solar_total_remaining_kwh=5.0 but weather is rainy, cloud 99%, \
+     current solar only 200W → MISALIGNED (LP overestimates solar)
+   - LP assumes buy_price_now=$0.15 and observed buy price is $0.15 → ALIGNED
 
-Phase 3 — Solar Ramp (11:00-13:00): Solar breaks through shade, 500W-4000W. \
-SoC climbs from 35% toward 60%+. Mode switches to solar_charge. \
-Grid import drops to near zero. This ramp happens every day.
+2. **Action-condition check**: Does the chosen action make sense given conditions?
+   - LP says grid_charge, weather is rainy, solar < 500W → ALIGNED \
+     (grid_charge compensates for missing solar)
+   - LP says solar_charge but current solar is 0W and cloud 100% → MISALIGNED
+   - LP says discharge during spike → ALIGNED (selling expensive)
 
-Phase 4 — Peak Solar (13:00-16:00): Solar 3000-5000W, battery charges at 2-4kW. \
-SoC climbs to 80-100%. On cloudy days, may only reach 70-80% — this is fine.
+3. **Outcome plausibility**: Are expected outcomes achievable?
+   - LP expects soc_at_sunset=95% but only 0.5 kWh solar remaining and SoC is 40% \
+     and no grid_charge planned → MISALIGNED
+   - LP expects soc_in_1h rising and it's grid_charging → ALIGNED
 
-Phase 5 — Evening Peak (17:00-21:00): TYPICALLY battery discharges at $0.20-0.30/kWh. \
-SoC drops from 80-100% toward 35-50%. Grid import near zero. \
-HOWEVER: if Amber band is very_low or extremely_low, grid_charge is correct — \
-the LP buys cheap grid now to avoid higher prices overnight. Do NOT flag this.
+## WHEN TO FLAG YELLOW
 
-Phase 6 — Late Evening (21:00-22:00): Prices drop, discharge slows. \
-SoC may drop to 30-40% before overnight hold kicks in.
-
-## CRITICAL: Weather overrides solar expectations
-
-The snapshot includes Weather, Cloud Coverage %, and Weather Confidence Factor. \
-On rainy days (confidence 0.5) or overcast days (confidence 0.7), solar output is \
-drastically reduced. The LP knows this and adjusts accordingly. \
-If weather is "rainy" or cloud > 90%, grid_charge is almost certainly correct — \
-the LP is compensating for missing solar. Do NOT flag grid_charge as "premature" \
-or "wasting solar" when weather confidence is low. The solar simply will not arrive.
-
-## CRITICAL: Amber band overrides time-of-day assumptions
-
-Wholesale pricing is volatile — the Amber Band in the snapshot ALWAYS takes precedence \
-over typical time-of-day patterns above. \
-extremely_low/very_low at ANY hour: grid_charge is rational (grid_charge_boost active). \
-high/spike at ANY hour: discharge is expected. Grid_charge during high/spike IS a concern.
-
-## WHEN TO FLAG YELLOW (genuine strategic concerns only)
-
-- Sunset target at risk: SoC < 70% after 15:00 with declining solar AND cloudy forecast
-- Unusual price pattern: spike predicted but battery is low, or extremely_low not being exploited
-- Multi-day trend: consecutive days of not reaching 95% by sunset suggests tuning issue
-- Load anomaly: sustained 3kW+ load (AC) that the trajectory doesn't account for
+ONLY when you find a concrete misalignment:
+- LP assumptions contradict observed sensor data
+- LP action contradicts its own stated reasoning
+- LP expected outcomes are physically impossible given constraints
 
 ## WHEN TO STAY GREEN
 
-- SoC at 30-35% overnight or during morning shading — this is the designed floor
-- Grid import during hold/floor — battery can't serve load at floor, grid fills the gap
-- Solar < 500W before 11am — trees, not clouds
-- SoC only reaching 75% on a cloudy day — system adapts, not a failure
-- Gentle overnight SoC decline — inverter efficiency losses, normal physics
-- Grid_charge during evening when Amber band is very_low or extremely_low — LP is buying cheap
-- Grid_charge on rainy/overcast days (confidence < 0.8) — LP compensates for missing solar
-- Grid_charge when current solar output < 500W and cloud > 80% — solar is physically unavailable
+- LP intent is coherent with observed conditions — even if you'd choose differently
+- You lack information to disprove an LP assumption — trust the LP
+- The LP has 24h of price/solar/load forecasts you don't see — if its reasoning \
+  is internally consistent with what you CAN see, it's GREEN
 
-Your default answer is GREEN. The system is well-tuned and operates correctly \
-the vast majority of the time. Return GREEN unless you can identify something \
-clearly wrong that does not match ANY of the normal phases above.
+Your default is GREEN. The LP is well-tuned and correct the vast majority of the \
+time. YELLOW only for concrete, provable misalignment between stated intent and \
+observed reality.
 
-YELLOW means: "this specific condition will cause meaningful financial loss or \
-miss a critical target if not addressed in the next 1-2 hours." A vague concern \
-or theoretical risk is not YELLOW — it must be concrete and imminent. If in doubt, \
-return GREEN.
+If GREEN: one sentence confirming alignment. \
+If YELLOW: state which specific assumption or action is misaligned and why.
 
-Keep it brief — one sentence for GREEN, 2-3 sentences only for YELLOW.
 Never return RED — deterministic checks handle critical issues.
 
 Respond in JSON only:

--- a/custom_components/victron_mpc/optimizer.py
+++ b/custom_components/victron_mpc/optimizer.py
@@ -98,6 +98,7 @@ class OptOutput:
     target_register: int  # Register 2901 value (100-1000)
     mode: str  # "grid_charge", "solar_charge", "discharge", "hold"
     reason: str  # Human-readable explanation
+    intent: dict  # Structured LP reasoning for GenAI validation
 
     # Full trajectories (length = horizon_steps + 1 for soc)
     soc_trajectory_pct: list[float]
@@ -480,12 +481,57 @@ def _build_output(result, inputs: OptInput, solve_ms: float) -> OptOutput:
         inputs.solar_forecast_kw[0], inputs.buy_price[0], inputs.sell_price[0],
     )
 
+    # Build structured intent — LP's reasoning chain for GenAI validation
+    solar_next_1h = sum(float(s) for s in inputs.solar_forecast_kw[:12]) * dt
+    load_next_1h = sum(float(l) for l in inputs.load_forecast_kw[:12]) * dt
+    solar_total_remaining = sum(float(s) for s in inputs.solar_forecast_kw) * dt
+    avg_buy_next_4h = (
+        sum(float(p) for p in inputs.buy_price[:min(48, N)]) / min(48, N)
+        if N > 0 else 0
+    )
+    peak_buy_next_4h = max(
+        (float(p) for p in inputs.buy_price[:min(48, N)]), default=0
+    )
+    soc_at_sunset = (
+        round(soc_pct[inputs.sunset_step], 1)
+        if inputs.sunset_step is not None and inputs.sunset_step < len(soc_pct)
+        else None
+    )
+
+    intent = {
+        "action": mode,
+        "why": reason,
+        "key_assumptions": {
+            "solar_next_1h_kwh": round(solar_next_1h, 2),
+            "solar_total_remaining_kwh": round(solar_total_remaining, 2),
+            "load_next_1h_kwh": round(load_next_1h, 2),
+            "buy_price_now": round(float(inputs.buy_price[0]), 4),
+            "avg_buy_next_4h": round(avg_buy_next_4h, 4),
+            "peak_buy_next_4h": round(peak_buy_next_4h, 4),
+        },
+        "expected_outcomes": {
+            "soc_in_1h_pct": round(soc_pct[min(12, len(soc_pct) - 1)], 1),
+            "soc_in_2h_pct": round(soc_pct[min(24, len(soc_pct) - 1)], 1),
+            "soc_at_sunset_pct": soc_at_sunset,
+            "total_cost_24h": round(grid_cost - export_revenue + wear_cost, 4),
+        },
+        "constraints_active": {
+            "sunset_target": inputs.sunset_step is not None,
+            "overnight_floor": any(
+                soc_pct[t] <= inputs.soc_min_kwh / inputs.battery_capacity_kwh * 100 + 2
+                for t in range(min(len(soc_pct), N))
+            ),
+            "spike_response": is_spike,
+        },
+    }
+
     return OptOutput(
         status="optimal",
         target_soc_pct=round(target_soc_pct, 1),
         target_register=target_register,
         mode=mode,
         reason=reason,
+        intent=intent,
         soc_trajectory_pct=[round(s, 1) for s in soc_pct],
         charge_schedule_kw=[round(float(v), 2) for v in p_charge],
         discharge_schedule_kw=[round(float(v), 2) for v in p_discharge],
@@ -518,6 +564,7 @@ def _build_fallback(inputs: OptInput, error_msg: str, solve_ms: float) -> OptOut
         target_register=_soc_to_register(target_pct),
         mode="hold",
         reason=f"Solver failed ({error_msg}), using safe fallback",
+        intent={"action": "hold", "why": f"Solver failed: {error_msg}", "key_assumptions": {}, "expected_outcomes": {}, "constraints_active": {}},
         soc_trajectory_pct=[round(target_pct, 1)] * (N + 1),
         charge_schedule_kw=[0.0] * N,
         discharge_schedule_kw=[0.0] * N,

--- a/custom_components/victron_mpc/sensor.py
+++ b/custom_components/victron_mpc/sensor.py
@@ -169,6 +169,50 @@ SENSOR_DESCRIPTIONS: tuple[VictronMPCSensorDescription, ...] = (
         if isinstance(data, dict)
         else {},
     ),
+    VictronMPCSensorDescription(
+        key="mpc_genai_audit_log",
+        attr_key="genai_audit_log",
+        translation_key="genai_audit_log",
+        icon="mdi:clipboard-text-clock",
+        state_class=SensorStateClass.MEASUREMENT,
+        attributes_fn=lambda data: {
+            "entries": data.get("entries", []),
+            "false_positive_count": data.get("false_positive_count", 0),
+            "prompt_version": data.get("prompt_version", "unknown"),
+            "current_version": data.get("current_version", "unknown"),
+            "version_stats": data.get("version_stats", {}),
+        }
+        if isinstance(data, dict)
+        else {},
+    ),
+    VictronMPCSensorDescription(
+        key="mpc_human_feedback",
+        attr_key="human_feedback",
+        translation_key="human_feedback",
+        icon="mdi:account-voice",
+        state_class=SensorStateClass.MEASUREMENT,
+        attributes_fn=lambda data: {
+            "entries": data.get("entries", []),
+            "disagreement_stats": data.get("disagreement_stats", {}),
+            "total_entries": data.get("total_entries", 0),
+        }
+        if isinstance(data, dict)
+        else {},
+    ),
+    VictronMPCSensorDescription(
+        key="mpc_modbus_write_log",
+        attr_key="modbus_write_log",
+        translation_key="modbus_write_log",
+        icon="mdi:database-clock",
+        state_class=SensorStateClass.MEASUREMENT,
+        attributes_fn=lambda data: {
+            "entries": data.get("entries", []),
+            "rogue_write_count": data.get("rogue_write_count", 0),
+            "total_writes": data.get("total_writes", 0),
+        }
+        if isinstance(data, dict)
+        else {},
+    ),
 )
 
 

--- a/custom_components/victron_mpc/services.yaml
+++ b/custom_components/victron_mpc/services.yaml
@@ -1,0 +1,54 @@
+emergency_stop:
+  name: Emergency Stop
+  description: >-
+    Immediately disable MPC optimization. Sets battery to safe floor (30%)
+    and blocks all export. All future optimization cycles are skipped until
+    emergency_resume is called.
+
+emergency_resume:
+  name: Emergency Resume
+  description: >-
+    Clear emergency stop and resume normal MPC optimization cycles.
+    The next optimization cycle will run on the regular 5-minute schedule.
+
+record_feedback:
+  name: Record Human Feedback
+  description: >-
+    Record a human verdict on the current MPC / UAT / GenAI assessment.
+    Use when you agree, disagree, or want to override the system's recommendation.
+    The verdict, your reasoning, and a system snapshot are stored for phase-transition
+    analysis (disagreement rate tracks how well the autonomous system matches human judgement).
+  fields:
+    human_verdict:
+      name: Human Verdict
+      description: "Your assessment: 'agree' (system is correct), 'disagree' (system is wrong), or 'override' (you are changing the decision)."
+      required: true
+      selector:
+        select:
+          options:
+            - agree
+            - disagree
+            - override
+    human_reasoning:
+      name: Human Reasoning
+      description: "Free-text explanation of your decision. This is the tacit knowledge that gets encoded."
+      required: true
+      selector:
+        text:
+          multiline: true
+    uat_verdict:
+      name: UAT Verdict
+      description: "The UAT assessment at the time of feedback (optional — copy from /uat output)."
+      required: false
+      selector:
+        text:
+    genai_verdict:
+      name: GenAI Verdict
+      description: "The GenAI health status at the time of feedback (optional — GREEN, YELLOW, or RED)."
+      required: false
+      selector:
+        select:
+          options:
+            - GREEN
+            - YELLOW
+            - RED

--- a/custom_components/victron_mpc/translations/en.json
+++ b/custom_components/victron_mpc/translations/en.json
@@ -96,7 +96,10 @@
       "solve_time": { "name": "Solver Time" },
       "genai_health": { "name": "GenAI Health" },
       "amber_forecast_accuracy": { "name": "Amber Forecast Accuracy" },
-      "appliance_monitor": { "name": "Appliance Monitor" }
+      "appliance_monitor": { "name": "Appliance Monitor" },
+      "genai_audit_log": { "name": "GenAI Audit Log" },
+      "human_feedback": { "name": "Human Feedback Log" },
+      "modbus_write_log": { "name": "Modbus Write Log" }
     },
     "number": {
       "battery_wear_cost": { "name": "Battery Wear Cost" },

--- a/tests/test_genai_audit_log.py
+++ b/tests/test_genai_audit_log.py
@@ -35,9 +35,9 @@ class TestPromptVersion:
         version_number = PROMPT_VERSION[1:]
         assert version_number.isdigit(), f"Version number should be numeric, got {version_number!r}"
 
-    def test_prompt_version_is_v4(self):
-        """PROMPT_VERSION is v4 matching the 4 iterations of prompt calibration."""
-        assert PROMPT_VERSION == "v4"
+    def test_prompt_version_is_v5(self):
+        """PROMPT_VERSION is v5 — added weather context to strategic snapshot."""
+        assert PROMPT_VERSION == "v5"
 
 
 # ======================================================================

--- a/tests/test_genai_audit_log.py
+++ b/tests/test_genai_audit_log.py
@@ -1,0 +1,589 @@
+"""Tests for GenAI audit log — Issue #57.
+
+Validates:
+- _append_genai_history includes all new structured fields
+- genai_audit_log sensor exposes correct state and attributes
+- Deduplication still works with new fields present
+- PROMPT_VERSION is importable and consistent
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.victron_mpc.genai_monitor import PROMPT_VERSION
+
+
+# ======================================================================
+# TestPromptVersion
+# ======================================================================
+
+
+class TestPromptVersion:
+    """PROMPT_VERSION constant is defined and importable."""
+
+    def test_prompt_version_is_string(self):
+        """PROMPT_VERSION is a non-empty string."""
+        assert isinstance(PROMPT_VERSION, str)
+        assert len(PROMPT_VERSION) > 0
+
+    def test_prompt_version_format(self):
+        """PROMPT_VERSION follows 'vN' convention."""
+        assert PROMPT_VERSION.startswith("v"), f"Expected 'vN' format, got {PROMPT_VERSION!r}"
+        version_number = PROMPT_VERSION[1:]
+        assert version_number.isdigit(), f"Version number should be numeric, got {version_number!r}"
+
+    def test_prompt_version_is_v4(self):
+        """PROMPT_VERSION is v4 matching the 4 iterations of prompt calibration."""
+        assert PROMPT_VERSION == "v4"
+
+
+# ======================================================================
+# Helper: minimal coordinator-like object with _append_genai_history
+# ======================================================================
+
+
+def _make_history_appender(max_entries: int = 168):
+    """Return an object that has the same _append_genai_history logic as the coordinator.
+
+    We import the method directly from coordinator to avoid instantiating the
+    full coordinator (which requires Home Assistant).
+    """
+    from custom_components.victron_mpc.coordinator import VictronMPCCoordinator
+
+    # Build a minimal mock that satisfies the method's attribute access
+    obj = MagicMock(spec=VictronMPCCoordinator)
+    obj._genai_history = []
+    obj._genai_history_max = max_entries
+
+    # Bind the real method to the mock object
+    obj._append_genai_history = VictronMPCCoordinator._append_genai_history.__get__(
+        obj, VictronMPCCoordinator
+    )
+    return obj
+
+
+# ======================================================================
+# TestAppendGenaiHistory — new structured fields
+# ======================================================================
+
+
+class TestAppendGenaiHistory:
+    """_append_genai_history stores all required fields in each entry."""
+
+    def _call(self, obj, *, source="deterministic", status="GREEN", summary="All OK",
+               soc_pct=50.0, mode="discharge", buy_price=0.25,
+               solar_w=1000, load_w=800, grid_import_w=0,
+               details="", deterministic_checks=None, amber_band="low", weather="clear"):
+        obj._append_genai_history(
+            source, status, summary,
+            soc_pct, mode, buy_price,
+            solar_w, load_w, grid_import_w,
+            details=details,
+            deterministic_checks=deterministic_checks,
+            amber_band=amber_band,
+            weather=weather,
+        )
+
+    def test_entry_contains_timestamp(self):
+        """Each history entry has an ISO 8601 timestamp."""
+        obj = _make_history_appender()
+        self._call(obj)
+        assert len(obj._genai_history) == 1
+        entry = obj._genai_history[0]
+        assert "timestamp" in entry
+        # Should be parseable ISO format
+        from datetime import datetime
+        datetime.fromisoformat(entry["timestamp"])
+
+    def test_entry_contains_prompt_version(self):
+        """Each entry records the prompt version used."""
+        obj = _make_history_appender()
+        self._call(obj)
+        entry = obj._genai_history[0]
+        assert "prompt_version" in entry
+        assert entry["prompt_version"] == PROMPT_VERSION
+
+    def test_entry_contains_details(self):
+        """Details field is stored in the entry."""
+        obj = _make_history_appender()
+        self._call(obj, details="Grid import anomaly detected at 1200W")
+        entry = obj._genai_history[0]
+        assert entry["details"] == "Grid import anomaly detected at 1200W"
+
+    def test_entry_details_defaults_to_empty_string(self):
+        """Details defaults to empty string when not provided."""
+        obj = _make_history_appender()
+        self._call(obj)
+        assert obj._genai_history[0]["details"] == ""
+
+    def test_entry_contains_deterministic_checks_list(self):
+        """deterministic_checks field is stored as a list."""
+        obj = _make_history_appender()
+        self._call(obj, deterministic_checks=["r2900_ess_mode", "grid_import_high"])
+        entry = obj._genai_history[0]
+        assert "deterministic_checks" in entry
+        assert entry["deterministic_checks"] == ["r2900_ess_mode", "grid_import_high"]
+
+    def test_entry_deterministic_checks_defaults_to_empty_list(self):
+        """deterministic_checks defaults to empty list when not provided."""
+        obj = _make_history_appender()
+        self._call(obj)
+        assert obj._genai_history[0]["deterministic_checks"] == []
+
+    def test_entry_contains_amber_band(self):
+        """amber_band field is stored in the entry."""
+        obj = _make_history_appender()
+        self._call(obj, amber_band="spike")
+        assert obj._genai_history[0]["amber_band"] == "spike"
+
+    def test_entry_amber_band_defaults_to_unknown(self):
+        """amber_band defaults to 'unknown' when not provided."""
+        obj = _make_history_appender()
+        self._call(obj)
+        assert obj._genai_history[0]["amber_band"] == "low"  # default in helper
+
+    def test_entry_contains_weather(self):
+        """weather field is stored in the entry."""
+        obj = _make_history_appender()
+        self._call(obj, weather="rainy")
+        assert obj._genai_history[0]["weather"] == "rainy"
+
+    def test_entry_contains_legacy_readings(self):
+        """Existing 'readings' dict is still present for backward compatibility."""
+        obj = _make_history_appender()
+        self._call(obj, soc_pct=62.5, mode="solar_charge", buy_price=0.31,
+                   solar_w=2500, load_w=900, grid_import_w=0)
+        entry = obj._genai_history[0]
+        assert "readings" in entry
+        readings = entry["readings"]
+        assert readings["soc_pct"] == 62.5
+        assert readings["mode"] == "solar_charge"
+        assert readings["buy_price"] == 0.31
+        assert readings["solar_w"] == 2500
+        assert readings["load_w"] == 900
+        assert readings["grid_import_w"] == 0
+
+    def test_entry_contains_source_status_summary(self):
+        """Legacy top-level fields source, status, summary are preserved."""
+        obj = _make_history_appender()
+        self._call(obj, source="genai", status="YELLOW", summary="Unusual pattern detected")
+        entry = obj._genai_history[0]
+        assert entry["source"] == "genai"
+        assert entry["status"] == "YELLOW"
+        assert entry["summary"] == "Unusual pattern detected"
+
+
+# ======================================================================
+# TestAppendGenaiHistoryDeduplication
+# ======================================================================
+
+
+class TestAppendGenaiHistoryDeduplication:
+    """Deduplication still works after adding new fields."""
+
+    def _append(self, obj, source="deterministic", status="GREEN", summary="OK", **kwargs):
+        obj._append_genai_history(
+            source, status, summary,
+            50.0, "discharge", 0.25, 1000, 800, 0,
+            **kwargs,
+        )
+
+    def test_duplicate_skipped(self):
+        """Same source/status/summary is not appended twice."""
+        obj = _make_history_appender()
+        self._append(obj)
+        self._append(obj)
+        assert len(obj._genai_history) == 1
+
+    def test_different_status_not_deduplicated(self):
+        """Different status results in a new entry."""
+        obj = _make_history_appender()
+        self._append(obj, status="GREEN")
+        self._append(obj, status="RED")
+        assert len(obj._genai_history) == 2
+
+    def test_different_summary_not_deduplicated(self):
+        """Different summary results in a new entry."""
+        obj = _make_history_appender()
+        self._append(obj, summary="All OK")
+        self._append(obj, summary="Grid import anomaly")
+        assert len(obj._genai_history) == 2
+
+    def test_different_source_not_deduplicated(self):
+        """Different source results in a new entry."""
+        obj = _make_history_appender()
+        self._append(obj, source="deterministic")
+        self._append(obj, source="genai")
+        assert len(obj._genai_history) == 2
+
+    def test_max_entries_enforced(self):
+        """History is capped at max_entries."""
+        obj = _make_history_appender(max_entries=5)
+        for i in range(10):
+            obj._append_genai_history(
+                "deterministic", "GREEN", f"summary_{i}",
+                50.0, "discharge", 0.25, 1000, 800, 0,
+            )
+        assert len(obj._genai_history) == 5
+        # Most recent entries retained
+        assert obj._genai_history[-1]["summary"] == "summary_9"
+
+
+# ======================================================================
+# TestGenaiAuditLogSensorData — _build_sensor_data shape
+# ======================================================================
+
+
+class TestGenaiAuditLogSensorData:
+    """genai_audit_log key in sensor_data has the correct structure."""
+
+    def _make_audit_log_data(self, history: list) -> dict:
+        """Simulate what _build_sensor_data puts in 'genai_audit_log'."""
+        return {
+            "state": len(history),
+            "entries": history,
+            "false_positive_count": sum(
+                1 for e in history if e.get("status") == "YELLOW"
+            ),
+            "prompt_version": PROMPT_VERSION,
+        }
+
+    def test_state_equals_entry_count(self):
+        """State field equals the number of history entries."""
+        history = [{"status": "GREEN"}, {"status": "RED"}]
+        data = self._make_audit_log_data(history)
+        assert data["state"] == 2
+
+    def test_entries_is_full_history(self):
+        """entries field contains all history entries."""
+        history = [{"status": "GREEN", "summary": "OK"}]
+        data = self._make_audit_log_data(history)
+        assert data["entries"] == history
+
+    def test_false_positive_count_counts_yellow(self):
+        """false_positive_count counts YELLOW entries."""
+        history = [
+            {"status": "GREEN"},
+            {"status": "YELLOW"},
+            {"status": "YELLOW"},
+            {"status": "RED"},
+        ]
+        data = self._make_audit_log_data(history)
+        assert data["false_positive_count"] == 2
+
+    def test_false_positive_count_zero_when_no_yellow(self):
+        """false_positive_count is 0 when no YELLOW entries."""
+        history = [{"status": "GREEN"}, {"status": "RED"}]
+        data = self._make_audit_log_data(history)
+        assert data["false_positive_count"] == 0
+
+    def test_prompt_version_matches_constant(self):
+        """prompt_version field matches the PROMPT_VERSION constant."""
+        data = self._make_audit_log_data([])
+        assert data["prompt_version"] == PROMPT_VERSION
+
+    def test_empty_history_state_is_zero(self):
+        """Empty history produces state=0."""
+        data = self._make_audit_log_data([])
+        assert data["state"] == 0
+
+
+# ======================================================================
+# TestGenaiAuditLogSensorDescription — sensor.py SENSOR_DESCRIPTIONS
+# ======================================================================
+
+
+class TestGenaiAuditLogSensorDescription:
+    """mpc_genai_audit_log is registered in SENSOR_DESCRIPTIONS."""
+
+    def test_sensor_key_exists(self):
+        """mpc_genai_audit_log appears in SENSOR_DESCRIPTIONS."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        keys = [desc.key for desc in SENSOR_DESCRIPTIONS]
+        assert "mpc_genai_audit_log" in keys, (
+            f"mpc_genai_audit_log not found in SENSOR_DESCRIPTIONS. Found: {keys}"
+        )
+
+    def test_sensor_attr_key(self):
+        """mpc_genai_audit_log maps to 'genai_audit_log' in coordinator data."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        assert desc.attr_key == "genai_audit_log"
+
+    def test_sensor_has_attributes_fn(self):
+        """mpc_genai_audit_log has an attributes_fn to expose rich attributes."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        assert desc.attributes_fn is not None, "attributes_fn must be set for genai_audit_log"
+
+    def test_attributes_fn_exposes_entries(self):
+        """attributes_fn extracts 'entries' from the data dict."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        sample_entries = [{"status": "GREEN", "timestamp": "2026-04-07T12:00:00"}]
+        data = {
+            "state": 1,
+            "entries": sample_entries,
+            "false_positive_count": 0,
+            "prompt_version": "v4",
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["entries"] == sample_entries
+
+    def test_attributes_fn_exposes_false_positive_count(self):
+        """attributes_fn extracts 'false_positive_count'."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        data = {
+            "state": 2,
+            "entries": [],
+            "false_positive_count": 3,
+            "prompt_version": "v4",
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["false_positive_count"] == 3
+
+    def test_attributes_fn_exposes_prompt_version(self):
+        """attributes_fn extracts 'prompt_version'."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        data = {
+            "state": 0,
+            "entries": [],
+            "false_positive_count": 0,
+            "prompt_version": "v4",
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["prompt_version"] == "v4"
+
+    def test_attributes_fn_handles_non_dict(self):
+        """attributes_fn returns empty dict for non-dict input (defensive)."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        assert desc.attributes_fn(None) == {}
+        assert desc.attributes_fn("string") == {}
+        assert desc.attributes_fn(42) == {}
+
+    def test_genai_health_sensor_still_exists(self):
+        """Existing mpc_genai_health sensor is not removed (backward compatibility)."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        keys = [desc.key for desc in SENSOR_DESCRIPTIONS]
+        assert "mpc_genai_health" in keys, "mpc_genai_health must not be removed"
+
+    def test_attributes_fn_exposes_version_stats(self):
+        """attributes_fn extracts 'version_stats' for #61 prompt calibration."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        version_stats = {"v4": {"total_assessments": 5, "yellow_rate": 0.2}}
+        data = {
+            "state": 5,
+            "entries": [],
+            "false_positive_count": 1,
+            "prompt_version": "v4",
+            "current_version": "v4",
+            "version_stats": version_stats,
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["version_stats"] == version_stats
+
+    def test_attributes_fn_exposes_current_version(self):
+        """attributes_fn extracts 'current_version' for #61 prompt calibration."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        data = {
+            "state": 0,
+            "entries": [],
+            "false_positive_count": 0,
+            "prompt_version": "v4",
+            "current_version": "v4",
+            "version_stats": {},
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["current_version"] == "v4"
+
+    def test_attributes_fn_version_stats_defaults_to_empty_dict(self):
+        """attributes_fn returns empty dict for version_stats when key missing."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_genai_audit_log")
+        data = {
+            "state": 0,
+            "entries": [],
+            "false_positive_count": 0,
+            "prompt_version": "v4",
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["version_stats"] == {}
+        assert attrs["current_version"] == "unknown"
+
+
+# ======================================================================
+# TestComputePromptVersionStats — #61 per-version statistics
+# ======================================================================
+
+
+def _make_stats_computer():
+    """Return an object bound with _compute_prompt_version_stats from coordinator."""
+    from custom_components.victron_mpc.coordinator import VictronMPCCoordinator
+
+    obj = MagicMock(spec=VictronMPCCoordinator)
+    obj._genai_history = []
+    obj._compute_prompt_version_stats = VictronMPCCoordinator._compute_prompt_version_stats.__get__(
+        obj, VictronMPCCoordinator
+    )
+    return obj
+
+
+class TestComputePromptVersionStats:
+    """_compute_prompt_version_stats groups entries and computes per-version metrics."""
+
+    def test_empty_history_returns_empty_dict(self):
+        """Empty _genai_history produces an empty stats dict."""
+        obj = _make_stats_computer()
+        stats = obj._compute_prompt_version_stats()
+        assert stats == {}
+
+    def test_single_version_green_entry(self):
+        """Single GREEN entry for one version produces correct counts."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {
+                "prompt_version": "v4",
+                "status": "GREEN",
+                "timestamp": "2026-04-07T10:00:00",
+            }
+        ]
+        stats = obj._compute_prompt_version_stats()
+        assert "v4" in stats
+        v4 = stats["v4"]
+        assert v4["total_assessments"] == 1
+        assert v4["green_count"] == 1
+        assert v4["yellow_count"] == 0
+        assert v4["error_count"] == 0
+        assert v4["yellow_rate"] == 0.0
+        assert v4["first_seen"] == "2026-04-07T10:00:00"
+        assert v4["last_seen"] == "2026-04-07T10:00:00"
+
+    def test_yellow_rate_calculation(self):
+        """yellow_rate = yellow_count / total_assessments."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T09:00:00"},
+            {"prompt_version": "v4", "status": "YELLOW", "timestamp": "2026-04-07T10:00:00"},
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T11:00:00"},
+            {"prompt_version": "v4", "status": "YELLOW", "timestamp": "2026-04-07T12:00:00"},
+        ]
+        stats = obj._compute_prompt_version_stats()
+        v4 = stats["v4"]
+        assert v4["total_assessments"] == 4
+        assert v4["yellow_count"] == 2
+        assert v4["green_count"] == 2
+        assert v4["yellow_rate"] == 0.5
+
+    def test_mixed_versions(self):
+        """Entries from different versions are grouped separately."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {"prompt_version": "v3", "status": "YELLOW", "timestamp": "2026-04-06T08:00:00"},
+            {"prompt_version": "v3", "status": "GREEN", "timestamp": "2026-04-06T09:00:00"},
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T10:00:00"},
+        ]
+        stats = obj._compute_prompt_version_stats()
+        assert set(stats.keys()) == {"v3", "v4"}
+        assert stats["v3"]["total_assessments"] == 2
+        assert stats["v3"]["yellow_count"] == 1
+        assert stats["v3"]["yellow_rate"] == 0.5
+        assert stats["v4"]["total_assessments"] == 1
+        assert stats["v4"]["yellow_count"] == 0
+        assert stats["v4"]["yellow_rate"] == 0.0
+
+    def test_error_skip_counted_in_error_count(self):
+        """ERROR, SKIP, and '?' statuses increment error_count."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {"prompt_version": "v4", "status": "ERROR", "timestamp": "2026-04-07T10:00:00"},
+            {"prompt_version": "v4", "status": "SKIP", "timestamp": "2026-04-07T10:05:00"},
+            {"prompt_version": "v4", "status": "?", "timestamp": "2026-04-07T10:10:00"},
+        ]
+        stats = obj._compute_prompt_version_stats()
+        v4 = stats["v4"]
+        assert v4["error_count"] == 3
+        assert v4["green_count"] == 0
+        assert v4["yellow_count"] == 0
+        assert v4["total_assessments"] == 3
+
+    def test_first_seen_last_seen_tracking(self):
+        """first_seen and last_seen track the timestamp range per version."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T12:00:00"},
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T08:00:00"},
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T10:00:00"},
+        ]
+        stats = obj._compute_prompt_version_stats()
+        v4 = stats["v4"]
+        assert v4["first_seen"] == "2026-04-07T08:00:00"
+        assert v4["last_seen"] == "2026-04-07T12:00:00"
+
+    def test_missing_prompt_version_grouped_as_unknown(self):
+        """Entries without prompt_version are grouped under 'unknown'."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {"status": "GREEN", "timestamp": "2026-04-07T10:00:00"},
+        ]
+        stats = obj._compute_prompt_version_stats()
+        assert "unknown" in stats
+        assert stats["unknown"]["total_assessments"] == 1
+
+    def test_yellow_rate_precision(self):
+        """yellow_rate is rounded to 4 decimal places."""
+        obj = _make_stats_computer()
+        obj._genai_history = [
+            {"prompt_version": "v4", "status": "YELLOW", "timestamp": "2026-04-07T10:00:00"},
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T10:05:00"},
+            {"prompt_version": "v4", "status": "GREEN", "timestamp": "2026-04-07T10:10:00"},
+        ]
+        stats = obj._compute_prompt_version_stats()
+        # 1/3 ≈ 0.3333
+        assert stats["v4"]["yellow_rate"] == round(1 / 3, 4)
+
+    def test_version_stats_returned_in_build_sensor_data(self):
+        """_build_sensor_data includes version_stats and current_version in genai_audit_log."""
+        obj = _make_history_appender()
+        obj._append_genai_history(
+            "deterministic", "GREEN", "All OK",
+            50.0, "discharge", 0.25, 1000, 800, 0,
+        )
+        # Bind _compute_prompt_version_stats to the same mock
+        from custom_components.victron_mpc.coordinator import VictronMPCCoordinator
+        obj._compute_prompt_version_stats = VictronMPCCoordinator._compute_prompt_version_stats.__get__(
+            obj, VictronMPCCoordinator
+        )
+        # Simulate what _build_sensor_data produces for genai_audit_log
+        genai_audit_log = {
+            "state": len(obj._genai_history),
+            "entries": obj._genai_history,
+            "false_positive_count": sum(
+                1 for e in obj._genai_history if e.get("status") == "YELLOW"
+            ),
+            "prompt_version": PROMPT_VERSION,
+            "current_version": PROMPT_VERSION,
+            "version_stats": obj._compute_prompt_version_stats(),
+        }
+        assert "version_stats" in genai_audit_log
+        assert "current_version" in genai_audit_log
+        assert genai_audit_log["current_version"] == PROMPT_VERSION
+        assert PROMPT_VERSION in genai_audit_log["version_stats"]

--- a/tests/test_genai_monitor.py
+++ b/tests/test_genai_monitor.py
@@ -368,21 +368,35 @@ class TestBuildStrategicSnapshot:
     """Tests for build_strategic_snapshot — inclusion/exclusion of fields."""
 
     def test_includes_strategic_fields(self):
-        """Snapshot includes mode, SoC, price, band."""
+        """Snapshot includes observed state and LP intent sections."""
         data = {
             "mode": "discharge",
             "battery_soc_pct": 72,
             "buy_price": 0.25,
             "solar_forecast_today": 18.5,
+            "decision": {
+                "state": "discharge",
+                "battery_soc_pct": 72,
+                "intent": {
+                    "action": "discharge",
+                    "why": "Discharging at 2.0kW",
+                    "key_assumptions": {"buy_price_now": 0.25},
+                    "expected_outcomes": {"soc_in_1h_pct": 65},
+                    "constraints_active": {},
+                },
+                "weather_confidence": 1.0,
+            },
         }
-        extra = {"amber_band": "neutral"}
+        extra = {"amber_band": "neutral", "weather": "clear"}
         snapshot = build_strategic_snapshot(data, extra)
 
-        assert "Mode: discharge" in snapshot
+        assert "OBSERVED STATE" in snapshot
+        assert "LP STATED INTENT" in snapshot
         assert "SoC: 72%" in snapshot
         assert "$0.25" in snapshot
         assert "Amber Band: neutral" in snapshot
         assert "18.5" in snapshot
+        assert "discharge" in snapshot.lower()
 
     def test_excludes_operational_fields(self):
         """Snapshot must NOT include registers, power flows."""
@@ -437,14 +451,16 @@ class TestBuildStrategicSnapshot:
                 "shadow_mode": False,
                 "grid_import_w": 0,
                 "schedule_30min": "[60, 65, 70]",
+                "weather_confidence": 1.0,
+                "intent": {"action": "solar_charge", "why": "Solar charging", "key_assumptions": {}, "expected_outcomes": {}, "constraints_active": {}},
             },
             "buy_price": {"state": 0.15},
             "solar_forecast_today": {"state": 20.0},
         }
-        extra = {"amber_band": "low"}
+        extra = {"amber_band": "low", "weather": "clear"}
         snapshot = build_strategic_snapshot(data, extra)
 
-        assert "Mode: solar_charge" in snapshot
+        assert "solar_charge" in snapshot
         assert "SoC: 60%" in snapshot
         assert "$0.15" in snapshot
         assert "Amber Band: low" in snapshot
@@ -932,7 +948,7 @@ class TestRunGenaiHealthCheck:
         call_kwargs = session.post.call_args
         payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
         system_content = payload["messages"][0]["content"]
-        assert "strategic" in system_content.lower()
+        assert "alignment" in system_content.lower()
         assert "Never return RED" in system_content
 
     @pytest.mark.asyncio

--- a/tests/test_human_feedback.py
+++ b/tests/test_human_feedback.py
@@ -1,0 +1,531 @@
+"""Tests for human feedback capture — Issue #60.
+
+Validates:
+- record_human_feedback stores all required fields correctly
+- _compute_disagreement_stats computes rates accurately
+- Maximum log size (200 entries) is enforced
+- human_feedback key in sensor data has the correct shape
+- Empty log edge cases are handled gracefully
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.victron_mpc.genai_monitor import PROMPT_VERSION
+
+
+# ======================================================================
+# Helpers: build minimal coordinator-like objects
+# ======================================================================
+
+
+def _make_feedback_coordinator(max_entries: int = 200):
+    """Return a mock bound with the human-feedback methods from the coordinator."""
+    from custom_components.victron_mpc.coordinator import VictronMPCCoordinator
+
+    obj = MagicMock(spec=VictronMPCCoordinator)
+    obj._human_feedback_log = []
+    obj._human_feedback_log_max = max_entries
+    obj._last_genai_result = {}
+    obj.data = None
+    # hass.states.get returns None by default
+    obj.hass = MagicMock()
+    obj.hass.states.get.return_value = None
+
+    # Bind real methods
+    obj.record_human_feedback = VictronMPCCoordinator.record_human_feedback.__get__(
+        obj, VictronMPCCoordinator
+    )
+    obj._compute_disagreement_stats = VictronMPCCoordinator._compute_disagreement_stats.__get__(
+        obj, VictronMPCCoordinator
+    )
+    return obj
+
+
+async def _record(obj, verdict="agree", reasoning="All good", uat="", genai=""):
+    """Helper to call record_human_feedback on the mock."""
+    await obj.record_human_feedback(
+        human_verdict=verdict,
+        human_reasoning=reasoning,
+        uat_verdict=uat,
+        genai_verdict=genai,
+    )
+
+
+# ======================================================================
+# TestRecordHumanFeedback — stored fields
+# ======================================================================
+
+
+class TestRecordHumanFeedback:
+    """record_human_feedback stores all required fields in each entry."""
+
+    def test_entry_stored_in_log(self):
+        """After one call, log has exactly one entry."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        assert len(obj._human_feedback_log) == 1
+
+    def test_entry_contains_timestamp(self):
+        """Each entry has a parseable ISO 8601 timestamp."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        entry = obj._human_feedback_log[0]
+        assert "timestamp" in entry
+        datetime.fromisoformat(entry["timestamp"])  # Must not raise
+
+    def test_entry_contains_human_verdict(self):
+        """human_verdict is stored verbatim."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(
+            _record(obj, verdict="disagree")
+        )
+        assert obj._human_feedback_log[0]["human_verdict"] == "disagree"
+
+    def test_entry_contains_human_reasoning(self):
+        """human_reasoning is stored verbatim."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(
+            _record(obj, reasoning="Battery should be charging now")
+        )
+        assert obj._human_feedback_log[0]["human_reasoning"] == "Battery should be charging now"
+
+    def test_entry_contains_uat_verdict(self):
+        """uat_verdict is stored when provided."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(
+            _record(obj, uat="PASS")
+        )
+        assert obj._human_feedback_log[0]["uat_verdict"] == "PASS"
+
+    def test_entry_contains_genai_verdict(self):
+        """genai_verdict is stored when provided."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(
+            _record(obj, genai="YELLOW")
+        )
+        assert obj._human_feedback_log[0]["genai_verdict"] == "YELLOW"
+
+    def test_entry_uat_defaults_to_empty_string(self):
+        """uat_verdict defaults to empty string when not provided."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        assert obj._human_feedback_log[0]["uat_verdict"] == ""
+
+    def test_entry_genai_defaults_to_empty_string(self):
+        """genai_verdict defaults to empty string when not provided."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        assert obj._human_feedback_log[0]["genai_verdict"] == ""
+
+    def test_entry_contains_genai_status_from_last_result(self):
+        """genai_status is taken from coordinator's _last_genai_result."""
+        obj = _make_feedback_coordinator()
+        obj._last_genai_result = {"status": "RED", "summary": "Grid import high"}
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        assert obj._human_feedback_log[0]["genai_status"] == "RED"
+
+    def test_entry_genai_status_empty_when_no_last_result(self):
+        """genai_status is empty string when _last_genai_result is empty."""
+        obj = _make_feedback_coordinator()
+        obj._last_genai_result = {}
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        assert obj._human_feedback_log[0]["genai_status"] == ""
+
+    def test_entry_contains_prompt_version(self):
+        """prompt_version matches PROMPT_VERSION constant."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        assert obj._human_feedback_log[0]["prompt_version"] == PROMPT_VERSION
+
+    def test_entry_contains_readings_snapshot(self):
+        """Each entry has a 'readings' dict with system snapshot keys."""
+        obj = _make_feedback_coordinator()
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        entry = obj._human_feedback_log[0]
+        assert "readings" in entry
+        readings = entry["readings"]
+        assert "soc_pct" in readings
+        assert "mode" in readings
+        assert "buy_price" in readings
+        assert "solar_w" in readings
+        assert "load_w" in readings
+        assert "grid_import_w" in readings
+        assert "amber_band" in readings
+        assert "weather" in readings
+
+    def test_readings_default_to_safe_values_when_no_data(self):
+        """Readings default to safe zero/unknown values when no coordinator data."""
+        obj = _make_feedback_coordinator()
+        obj.data = None
+        asyncio.get_event_loop().run_until_complete(_record(obj))
+        readings = obj._human_feedback_log[0]["readings"]
+        # All numeric defaults should be 0 or 0.0 — not exceptions
+        assert isinstance(readings["soc_pct"], (int, float))
+        assert isinstance(readings["solar_w"], int)
+        assert isinstance(readings["load_w"], int)
+        assert isinstance(readings["grid_import_w"], int)
+
+    def test_all_verdict_types_accepted(self):
+        """All three verdict types can be stored without errors."""
+        obj = _make_feedback_coordinator()
+        for verdict in ("agree", "disagree", "override"):
+            asyncio.get_event_loop().run_until_complete(
+                _record(obj, verdict=verdict)
+            )
+        verdicts = [e["human_verdict"] for e in obj._human_feedback_log]
+        assert "agree" in verdicts
+        assert "disagree" in verdicts
+        assert "override" in verdicts
+
+
+# ======================================================================
+# TestMaxLogSize — enforces 200-entry cap
+# ======================================================================
+
+
+class TestMaxLogSize:
+    """Log is trimmed to max_entries when exceeded."""
+
+    def test_log_capped_at_max_entries(self):
+        """After 210 entries with max=200, log has exactly 200."""
+        obj = _make_feedback_coordinator(max_entries=200)
+        for i in range(210):
+            asyncio.get_event_loop().run_until_complete(
+                _record(obj, reasoning=f"entry_{i}")
+            )
+        assert len(obj._human_feedback_log) == 200
+
+    def test_most_recent_entries_retained_after_trim(self):
+        """After trimming, the most recent entries are kept."""
+        obj = _make_feedback_coordinator(max_entries=5)
+        for i in range(8):
+            asyncio.get_event_loop().run_until_complete(
+                _record(obj, reasoning=f"entry_{i}")
+            )
+        assert len(obj._human_feedback_log) == 5
+        # Last entry should be entry_7
+        assert obj._human_feedback_log[-1]["human_reasoning"] == "entry_7"
+        # First entry should be entry_3 (oldest retained)
+        assert obj._human_feedback_log[0]["human_reasoning"] == "entry_3"
+
+    def test_small_log_not_trimmed_unnecessarily(self):
+        """Log under max_entries is not trimmed."""
+        obj = _make_feedback_coordinator(max_entries=200)
+        for i in range(5):
+            asyncio.get_event_loop().run_until_complete(
+                _record(obj, reasoning=f"entry_{i}")
+            )
+        assert len(obj._human_feedback_log) == 5
+
+
+# ======================================================================
+# TestComputeDisagreementStats
+# ======================================================================
+
+
+class TestComputeDisagreementStats:
+    """_compute_disagreement_stats computes accurate rates."""
+
+    def test_empty_log_returns_zero_stats(self):
+        """Empty log produces all-zero stats."""
+        obj = _make_feedback_coordinator()
+        stats = obj._compute_disagreement_stats()
+        assert stats["total_feedback"] == 0
+        assert stats["disagree_count"] == 0
+        assert stats["agree_count"] == 0
+        assert stats["disagreement_rate"] == 0.0
+
+    def test_empty_log_recent_7d_is_zero(self):
+        """Empty log produces all-zero recent_7d stats."""
+        obj = _make_feedback_coordinator()
+        stats = obj._compute_disagreement_stats()
+        r = stats["recent_7d"]
+        assert r["total_feedback"] == 0
+        assert r["disagree_count"] == 0
+        assert r["disagreement_rate"] == 0.0
+
+    def test_disagree_count_correct(self):
+        """disagree_count counts only 'disagree' verdicts."""
+        obj = _make_feedback_coordinator()
+        obj._human_feedback_log = [
+            {"human_verdict": "agree", "timestamp": datetime.now().isoformat()},
+            {"human_verdict": "disagree", "timestamp": datetime.now().isoformat()},
+            {"human_verdict": "disagree", "timestamp": datetime.now().isoformat()},
+            {"human_verdict": "override", "timestamp": datetime.now().isoformat()},
+        ]
+        stats = obj._compute_disagreement_stats()
+        assert stats["total_feedback"] == 4
+        assert stats["disagree_count"] == 2
+        assert stats["agree_count"] == 1
+
+    def test_disagreement_rate_calculation(self):
+        """disagreement_rate = disagree_count / total_feedback."""
+        obj = _make_feedback_coordinator()
+        obj._human_feedback_log = [
+            {"human_verdict": "agree", "timestamp": datetime.now().isoformat()},
+            {"human_verdict": "disagree", "timestamp": datetime.now().isoformat()},
+        ]
+        stats = obj._compute_disagreement_stats()
+        assert stats["disagreement_rate"] == 0.5
+
+    def test_disagreement_rate_rounded_to_4_decimal_places(self):
+        """disagreement_rate is rounded to 4 decimal places."""
+        obj = _make_feedback_coordinator()
+        obj._human_feedback_log = [
+            {"human_verdict": "disagree", "timestamp": datetime.now().isoformat()},
+            {"human_verdict": "agree", "timestamp": datetime.now().isoformat()},
+            {"human_verdict": "agree", "timestamp": datetime.now().isoformat()},
+        ]
+        stats = obj._compute_disagreement_stats()
+        # 1/3 ≈ 0.3333
+        assert stats["disagreement_rate"] == round(1 / 3, 4)
+
+    def test_recent_7d_filters_old_entries(self):
+        """recent_7d only includes entries from the last 7 days."""
+        obj = _make_feedback_coordinator()
+        old_ts = (datetime.now() - timedelta(days=8)).isoformat(timespec="seconds")
+        new_ts = datetime.now().isoformat(timespec="seconds")
+        obj._human_feedback_log = [
+            {"human_verdict": "disagree", "timestamp": old_ts},
+            {"human_verdict": "agree", "timestamp": new_ts},
+            {"human_verdict": "disagree", "timestamp": new_ts},
+        ]
+        stats = obj._compute_disagreement_stats()
+        # Total includes all 3
+        assert stats["total_feedback"] == 3
+        assert stats["disagree_count"] == 2
+        # Recent only includes the 2 new ones
+        r = stats["recent_7d"]
+        assert r["total_feedback"] == 2
+        assert r["disagree_count"] == 1
+        assert r["agree_count"] == 1
+        assert r["disagreement_rate"] == 0.5
+
+    def test_all_agree_zero_disagreement_rate(self):
+        """100% agree gives disagreement_rate of 0.0."""
+        obj = _make_feedback_coordinator()
+        obj._human_feedback_log = [
+            {"human_verdict": "agree", "timestamp": datetime.now().isoformat()}
+            for _ in range(10)
+        ]
+        stats = obj._compute_disagreement_stats()
+        assert stats["disagreement_rate"] == 0.0
+
+    def test_all_disagree_gives_rate_one(self):
+        """100% disagree gives disagreement_rate of 1.0."""
+        obj = _make_feedback_coordinator()
+        obj._human_feedback_log = [
+            {"human_verdict": "disagree", "timestamp": datetime.now().isoformat()}
+            for _ in range(5)
+        ]
+        stats = obj._compute_disagreement_stats()
+        assert stats["disagreement_rate"] == 1.0
+
+    def test_stats_has_required_keys(self):
+        """Stats dict has all required keys."""
+        obj = _make_feedback_coordinator()
+        stats = obj._compute_disagreement_stats()
+        required = {"total_feedback", "disagree_count", "agree_count", "disagreement_rate", "recent_7d"}
+        assert required.issubset(set(stats.keys()))
+
+    def test_recent_7d_has_required_keys(self):
+        """recent_7d sub-dict has all required keys."""
+        obj = _make_feedback_coordinator()
+        stats = obj._compute_disagreement_stats()
+        r = stats["recent_7d"]
+        required = {"total_feedback", "disagree_count", "agree_count", "disagreement_rate"}
+        assert required.issubset(set(r.keys()))
+
+
+# ======================================================================
+# TestSensorDataShape — human_feedback key in _build_sensor_data output
+# ======================================================================
+
+
+class TestSensorDataShape:
+    """human_feedback in sensor data has the correct structure."""
+
+    def _make_human_feedback_data(self, log: list) -> dict:
+        """Simulate what _build_sensor_data produces for 'human_feedback'."""
+        # Replicate the exact structure from coordinator._build_sensor_data
+        total = len(log)
+        disagree = sum(1 for e in log if e.get("human_verdict") == "disagree")
+        agree = sum(1 for e in log if e.get("human_verdict") == "agree")
+        rate = round(disagree / total, 4) if total > 0 else 0.0
+        return {
+            "state": total,
+            "entries": log[-50:],
+            "disagreement_stats": {
+                "total_feedback": total,
+                "disagree_count": disagree,
+                "agree_count": agree,
+                "disagreement_rate": rate,
+                "recent_7d": {
+                    "total_feedback": total,
+                    "disagree_count": disagree,
+                    "agree_count": agree,
+                    "disagreement_rate": rate,
+                },
+            },
+            "total_entries": total,
+        }
+
+    def test_state_equals_log_length(self):
+        """state field equals the total number of feedback entries."""
+        log = [{"human_verdict": "agree"}, {"human_verdict": "disagree"}]
+        data = self._make_human_feedback_data(log)
+        assert data["state"] == 2
+
+    def test_entries_capped_at_50(self):
+        """entries field contains at most 50 entries."""
+        log = [{"human_verdict": "agree"} for _ in range(60)]
+        data = self._make_human_feedback_data(log)
+        assert len(data["entries"]) == 50
+
+    def test_entries_has_most_recent_when_truncated(self):
+        """When log > 50, entries contains the most recent 50."""
+        log = [{"human_verdict": "agree", "idx": i} for i in range(60)]
+        data = self._make_human_feedback_data(log)
+        # Most recent entry should have idx=59
+        assert data["entries"][-1]["idx"] == 59
+        # Oldest in entries should have idx=10
+        assert data["entries"][0]["idx"] == 10
+
+    def test_total_entries_is_full_log_length(self):
+        """total_entries reflects total, even when entries is truncated."""
+        log = [{"human_verdict": "agree"} for _ in range(75)]
+        data = self._make_human_feedback_data(log)
+        assert data["total_entries"] == 75
+        assert len(data["entries"]) == 50
+
+    def test_disagreement_stats_present(self):
+        """disagreement_stats key is present in sensor data."""
+        data = self._make_human_feedback_data([])
+        assert "disagreement_stats" in data
+
+    def test_empty_log_state_is_zero(self):
+        """Empty log produces state=0."""
+        data = self._make_human_feedback_data([])
+        assert data["state"] == 0
+        assert data["total_entries"] == 0
+
+
+# ======================================================================
+# TestHumanFeedbackSensorDescription — sensor.py SENSOR_DESCRIPTIONS
+# ======================================================================
+
+
+class TestHumanFeedbackSensorDescription:
+    """mpc_human_feedback is registered in SENSOR_DESCRIPTIONS."""
+
+    def test_sensor_key_exists(self):
+        """mpc_human_feedback appears in SENSOR_DESCRIPTIONS."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        keys = [desc.key for desc in SENSOR_DESCRIPTIONS]
+        assert "mpc_human_feedback" in keys, (
+            f"mpc_human_feedback not found in SENSOR_DESCRIPTIONS. Found: {keys}"
+        )
+
+    def test_sensor_attr_key(self):
+        """mpc_human_feedback maps to 'human_feedback' in coordinator data."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_human_feedback")
+        assert desc.attr_key == "human_feedback"
+
+    def test_sensor_has_attributes_fn(self):
+        """mpc_human_feedback has an attributes_fn to expose rich attributes."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_human_feedback")
+        assert desc.attributes_fn is not None
+
+    def test_attributes_fn_exposes_entries(self):
+        """attributes_fn extracts 'entries' from the data dict."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_human_feedback")
+        sample_entries = [{"human_verdict": "agree", "timestamp": "2026-04-07T10:00:00"}]
+        data = {
+            "state": 1,
+            "entries": sample_entries,
+            "disagreement_stats": {},
+            "total_entries": 1,
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["entries"] == sample_entries
+
+    def test_attributes_fn_exposes_disagreement_stats(self):
+        """attributes_fn extracts 'disagreement_stats' from the data dict."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_human_feedback")
+        stats = {"total_feedback": 5, "disagreement_rate": 0.4}
+        data = {
+            "state": 5,
+            "entries": [],
+            "disagreement_stats": stats,
+            "total_entries": 5,
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["disagreement_stats"] == stats
+
+    def test_attributes_fn_exposes_total_entries(self):
+        """attributes_fn extracts 'total_entries' from the data dict."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_human_feedback")
+        data = {
+            "state": 75,
+            "entries": [],
+            "disagreement_stats": {},
+            "total_entries": 75,
+        }
+        attrs = desc.attributes_fn(data)
+        assert attrs["total_entries"] == 75
+
+    def test_attributes_fn_handles_non_dict(self):
+        """attributes_fn returns empty dict for non-dict input (defensive)."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "mpc_human_feedback")
+        assert desc.attributes_fn(None) == {}
+        assert desc.attributes_fn("string") == {}
+        assert desc.attributes_fn(42) == {}
+
+    def test_existing_sensors_not_removed(self):
+        """Existing sensors are not removed — backward compatibility."""
+        from custom_components.victron_mpc.sensor import SENSOR_DESCRIPTIONS
+
+        keys = [desc.key for desc in SENSOR_DESCRIPTIONS]
+        for expected in ("mpc_genai_audit_log", "mpc_genai_health", "mpc_decision"):
+            assert expected in keys, f"{expected} must not be removed"
+
+
+# ======================================================================
+# TestServiceRegistration — __init__.py service wiring
+# ======================================================================
+
+
+class TestServiceRegistration:
+    """record_feedback service constant is defined in __init__.py."""
+
+    def test_service_constant_exists(self):
+        """SERVICE_RECORD_FEEDBACK constant is importable from __init__."""
+        from custom_components.victron_mpc import SERVICE_RECORD_FEEDBACK
+
+        assert SERVICE_RECORD_FEEDBACK == "record_feedback"
+
+    def test_service_constant_string(self):
+        """SERVICE_RECORD_FEEDBACK is a non-empty string."""
+        from custom_components.victron_mpc import SERVICE_RECORD_FEEDBACK
+
+        assert isinstance(SERVICE_RECORD_FEEDBACK, str)
+        assert len(SERVICE_RECORD_FEEDBACK) > 0

--- a/tests/test_modbus_health.py
+++ b/tests/test_modbus_health.py
@@ -42,6 +42,9 @@ def _make_coordinator(*, readback_pct: float = -1) -> VictronMPCCoordinator:
     coord._last_register_value = None
     coord._last_feedin_value = None
     coord._last_mode = None
+    coord._cycle_count = 0
+    coord._modbus_write_log = []
+    coord._modbus_write_log_max = 2016
 
     # Mock _get_r2901_readback to return the specified value
     coord._get_r2901_readback = MagicMock(return_value=readback_pct)

--- a/tests/test_modbus_write_log.py
+++ b/tests/test_modbus_write_log.py
@@ -1,0 +1,383 @@
+"""Tests for Issue #65: Modbus write audit log with source identification and rogue write detection."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.victron_mpc.coordinator import VictronMPCCoordinator
+
+
+def _make_coordinator(*, readback_pct: float = -1) -> VictronMPCCoordinator:
+    """Create a minimal coordinator with mocked hass and config entry.
+
+    Args:
+        readback_pct: Value returned by _get_r2901_readback().
+            -1 means sensor unavailable (default).
+            A positive float simulates a sensor reading (e.g. 50.0 = 50%).
+    """
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry_123"
+    entry.data = {
+        "modbus_hub": "cerbo",
+        "modbus_slave_system": 100,
+    }
+    entry.options = {}
+
+    with patch.object(VictronMPCCoordinator, "__init__", lambda self, *a, **kw: None):
+        coord = VictronMPCCoordinator.__new__(VictronMPCCoordinator)
+
+    # Set attributes that __init__ would normally set
+    coord.hass = hass
+    coord.entry = entry
+    coord._modbus_consecutive_failures = 0
+    coord._modbus_last_success = None
+    coord._modbus_alerted = False
+    coord._last_register_value = None
+    coord._last_feedin_value = None
+    coord._last_mode = None
+    coord._cycle_count = 42  # Non-zero for realistic tests
+    coord._modbus_write_log = []
+    coord._modbus_write_log_max = 2016
+
+    # Mock _get_r2901_readback
+    coord._get_r2901_readback = MagicMock(return_value=readback_pct)
+
+    return coord
+
+
+class TestR2901WriteAppendsToLog:
+    """R2901 (_write_register) writes must appear in the audit log."""
+
+    @pytest.mark.asyncio
+    async def test_successful_write_appends_log_entry(self):
+        """A successful R2901 write creates one log entry with correct fields."""
+        coord = _make_coordinator(readback_pct=-1)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        assert len(coord._modbus_write_log) == 1
+        entry = coord._modbus_write_log[0]
+        assert entry["register"] == 2901
+        assert entry["register_name"] == "ess_min_soc"
+        assert entry["value"] == 500
+        assert entry["source"] == "hacs_mpc"
+        assert entry["cycle"] == 42
+        assert "timestamp" in entry
+
+    @pytest.mark.asyncio
+    async def test_log_entry_previous_value_is_none_on_first_write(self):
+        """First write has previous_value=None (not yet tracked)."""
+        coord = _make_coordinator(readback_pct=-1)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        entry = coord._modbus_write_log[0]
+        assert entry["previous_value"] is None
+
+    @pytest.mark.asyncio
+    async def test_log_entry_previous_value_tracks_prior_write(self):
+        """After a first write, a second write records previous_value correctly."""
+        coord = _make_coordinator(readback_pct=-1)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(300)
+            await coord._write_register(500)
+
+        assert len(coord._modbus_write_log) == 2
+        assert coord._modbus_write_log[1]["previous_value"] == 300
+        assert coord._modbus_write_log[1]["value"] == 500
+
+    @pytest.mark.asyncio
+    async def test_log_entry_verified_none_when_sensor_unavailable(self):
+        """verified=None when readback sensor is unavailable."""
+        coord = _make_coordinator(readback_pct=-1)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        entry = coord._modbus_write_log[0]
+        assert entry["verified"] is None
+        assert entry["readback_value"] is None
+
+    @pytest.mark.asyncio
+    async def test_log_entry_verified_true_on_matching_readback(self):
+        """verified=True when readback matches within tolerance."""
+        coord = _make_coordinator(readback_pct=50.0)  # 500 / 10 = 50.0%
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        entry = coord._modbus_write_log[0]
+        assert entry["verified"] is True
+        assert entry["readback_value"] == 50.0
+
+    @pytest.mark.asyncio
+    async def test_log_entry_verified_false_on_persistent_mismatch(self):
+        """verified=False when readback never matches after retry."""
+        coord = _make_coordinator()
+        # Both readbacks return wrong value — 99.0% when we wrote 500 (50%)
+        coord._get_r2901_readback = MagicMock(return_value=99.0)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        # First entry is our write, second is the rogue write suspect
+        normal_entries = [e for e in coord._modbus_write_log if e.get("source") == "hacs_mpc"]
+        assert len(normal_entries) == 1
+        assert normal_entries[0]["verified"] is False
+
+    @pytest.mark.asyncio
+    async def test_write_skip_unchanged_value_does_not_append(self):
+        """Skipped writes (value unchanged) must not append to the log."""
+        coord = _make_coordinator(readback_pct=-1)
+        coord._last_register_value = 500
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        assert len(coord._modbus_write_log) == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_write_does_not_append_to_log(self):
+        """A Modbus exception on write must not append a log entry."""
+        coord = _make_coordinator()
+        coord.hass.services.async_call = AsyncMock(side_effect=Exception("timeout"))
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        assert len(coord._modbus_write_log) == 0
+
+    @pytest.mark.asyncio
+    async def test_log_entry_contains_mode(self):
+        """Log entry records current mode at time of write."""
+        coord = _make_coordinator(readback_pct=-1)
+        coord._last_mode = "hold"
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(300)
+
+        assert coord._modbus_write_log[0]["mode"] == "hold"
+
+
+class TestR2706WriteAppendsToLog:
+    """R2706 (_write_feedin_register) writes must appear in the audit log."""
+
+    @pytest.mark.asyncio
+    async def test_feedin_write_appends_log_entry(self):
+        """A successful R2706 write creates one log entry."""
+        coord = _make_coordinator()
+
+        await coord._write_feedin_register(70)
+
+        assert len(coord._modbus_write_log) == 1
+        entry = coord._modbus_write_log[0]
+        assert entry["register"] == 2706
+        assert entry["register_name"] == "max_feed_in"
+        assert entry["value"] == 70
+        assert entry["source"] == "hacs_mpc"
+        assert entry["verified"] is None  # No read-back on R2706
+        assert entry["readback_value"] is None
+
+    @pytest.mark.asyncio
+    async def test_feedin_write_records_previous_value(self):
+        """Feed-in log entry captures the previous feed-in value."""
+        coord = _make_coordinator()
+        coord._last_feedin_value = 0  # Previously blocked
+
+        await coord._write_feedin_register(70)
+
+        assert coord._modbus_write_log[0]["previous_value"] == 0
+
+    @pytest.mark.asyncio
+    async def test_feedin_skip_unchanged_does_not_append(self):
+        """Skipped feed-in writes must not append to the log."""
+        coord = _make_coordinator()
+        coord._last_feedin_value = 70
+
+        await coord._write_feedin_register(70)
+
+        assert len(coord._modbus_write_log) == 0
+
+    @pytest.mark.asyncio
+    async def test_feedin_write_failure_does_not_append(self):
+        """A failed R2706 write must not append to the log."""
+        coord = _make_coordinator()
+        coord.hass.services.async_call = AsyncMock(side_effect=Exception("timeout"))
+
+        await coord._write_feedin_register(70)
+
+        assert len(coord._modbus_write_log) == 0
+
+
+class TestR2900WriteAppendsToLog:
+    """R2900 (_write_batterylife_register) writes must appear in the audit log."""
+
+    @pytest.mark.asyncio
+    async def test_batterylife_write_appends_log_entry(self):
+        """A successful R2900 write creates one log entry."""
+        coord = _make_coordinator()
+
+        await coord._write_batterylife_register()
+
+        assert len(coord._modbus_write_log) == 1
+        entry = coord._modbus_write_log[0]
+        assert entry["register"] == 2900
+        assert entry["register_name"] == "batterylife_state"
+        assert entry["value"] == 12
+        assert entry["source"] == "hacs_mpc"
+        assert entry["verified"] is None  # No read-back on R2900
+        assert entry["readback_value"] is None
+
+    @pytest.mark.asyncio
+    async def test_batterylife_write_failure_does_not_append(self):
+        """A failed R2900 write must not append to the log."""
+        coord = _make_coordinator()
+        coord.hass.services.async_call = AsyncMock(side_effect=Exception("timeout"))
+
+        await coord._write_batterylife_register()
+
+        assert len(coord._modbus_write_log) == 0
+
+
+class TestRogueWriteDetection:
+    """Persistent readback mismatch triggers a rogue write suspicion entry."""
+
+    @pytest.mark.asyncio
+    async def test_persistent_mismatch_appends_rogue_entry(self):
+        """After persistent mismatch, a 'unknown_external' entry is added."""
+        coord = _make_coordinator()
+        # Readback always shows 99.0% regardless of what we write
+        coord._get_r2901_readback = MagicMock(return_value=99.0)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        rogue_entries = [e for e in coord._modbus_write_log if e.get("source") == "unknown_external"]
+        assert len(rogue_entries) == 1
+        rogue = rogue_entries[0]
+        assert rogue["alert"] is True
+        assert rogue["register"] == 2901
+        assert rogue["expected_value"] == 500
+        assert rogue["actual_value"] == 990  # 99.0 * 10
+
+    @pytest.mark.asyncio
+    async def test_first_attempt_mismatch_then_success_no_rogue_entry(self):
+        """Mismatch on attempt 1 but success on attempt 2 does NOT flag rogue."""
+        coord = _make_coordinator()
+        # First readback: wrong, second: correct (50%)
+        coord._get_r2901_readback = MagicMock(side_effect=[70.0, 50.0])
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        rogue_entries = [e for e in coord._modbus_write_log if e.get("source") == "unknown_external"]
+        assert len(rogue_entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_successful_write_no_rogue_entry(self):
+        """A verified write creates no rogue entries."""
+        coord = _make_coordinator(readback_pct=50.0)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        rogue_entries = [e for e in coord._modbus_write_log if e.get("source") == "unknown_external"]
+        assert len(rogue_entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_unavailable_readback_no_rogue_entry(self):
+        """Unavailable readback (sensor -1) must not flag a rogue write."""
+        coord = _make_coordinator(readback_pct=-1)
+
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        rogue_entries = [e for e in coord._modbus_write_log if e.get("source") == "unknown_external"]
+        assert len(rogue_entries) == 0
+
+
+class TestMaxLogSize:
+    """Log must not grow beyond max size."""
+
+    @pytest.mark.asyncio
+    async def test_log_respects_max_size(self):
+        """Log trims to max_size, keeping the most recent entries."""
+        coord = _make_coordinator(readback_pct=-1)
+        coord._modbus_write_log_max = 5
+        # Pre-fill log to just below max
+        coord._modbus_write_log = [{"cycle": i} for i in range(5)]
+
+        # Write one more — should push out the oldest
+        with patch("custom_components.victron_mpc.coordinator.asyncio.sleep", new_callable=AsyncMock):
+            await coord._write_register(500)
+
+        assert len(coord._modbus_write_log) == 5
+        # Most recent entry is our write
+        assert coord._modbus_write_log[-1]["register"] == 2901
+
+    @pytest.mark.asyncio
+    async def test_log_default_max_is_2016(self):
+        """The default log max is 2016 entries (7 days × 288 cycles/day)."""
+        coord = _make_coordinator()
+        assert coord._modbus_write_log_max == 2016
+
+
+class TestSensorDataShape:
+    """modbus_write_log key in _build_sensor_data() has required structure."""
+
+    def test_sensor_data_shape_empty_log(self):
+        """With an empty log, sensor data has correct zero values."""
+        coord = _make_coordinator()
+        # Build the dict that _build_sensor_data would produce
+        write_log_data = {
+            "state": len(coord._modbus_write_log),
+            "entries": coord._modbus_write_log[-50:],
+            "rogue_write_count": sum(
+                1 for e in coord._modbus_write_log if e.get("source") == "unknown_external"
+            ),
+            "total_writes": len(coord._modbus_write_log),
+        }
+        assert write_log_data["state"] == 0
+        assert write_log_data["entries"] == []
+        assert write_log_data["rogue_write_count"] == 0
+        assert write_log_data["total_writes"] == 0
+
+    def test_sensor_data_rogue_write_count(self):
+        """rogue_write_count correctly counts unknown_external source entries."""
+        coord = _make_coordinator()
+        coord._modbus_write_log = [
+            {"source": "hacs_mpc", "register": 2901},
+            {"source": "unknown_external", "register": 2901, "alert": True},
+            {"source": "hacs_mpc", "register": 2706},
+            {"source": "unknown_external", "register": 2901, "alert": True},
+        ]
+        rogue_count = sum(
+            1 for e in coord._modbus_write_log if e.get("source") == "unknown_external"
+        )
+        assert rogue_count == 2
+
+    def test_sensor_data_entries_capped_at_50(self):
+        """entries in sensor data is limited to last 50 entries."""
+        coord = _make_coordinator()
+        coord._modbus_write_log = [{"cycle": i} for i in range(100)]
+        entries = coord._modbus_write_log[-50:]
+        assert len(entries) == 50
+        # Should be the most recent 50
+        assert entries[0]["cycle"] == 50
+        assert entries[-1]["cycle"] == 99
+
+    def test_sensor_data_total_writes_reflects_all_entries(self):
+        """total_writes is the full log count, not capped at 50."""
+        coord = _make_coordinator()
+        coord._modbus_write_log = [{"cycle": i} for i in range(100)]
+        total_writes = len(coord._modbus_write_log)
+        assert total_writes == 100


### PR DESCRIPTION
## Summary

Batch implementation of 5 issues from Milestone 11 (Governance) and Milestone 12 (Security):

- **#57** — GenAI assessment audit log: structured history entries with prompt version, deterministic check results, weather/amber context
- **#61** — GenAI prompt versioning: per-version false positive rate tracking (`version_stats` attribute)
- **#60** — Human feedback capture: `record_feedback` HA service with disagreement rate stats for phase transitions
- **#65** — Modbus write audit log: every register write logged with source ID, rogue write detection on persistent read-back mismatch
- **#67** — Secrets audit: git history scanned (2 HA tokens found in tracked docs — recommend revoking), pre-commit hook installed

### New Sensors
| Sensor | State | Key Attributes |
|--------|-------|----------------|
| `mpc_genai_audit_log` | entry count | entries, version_stats, current_version, false_positive_count |
| `mpc_human_feedback` | entry count | entries, disagreement_stats (overall + 7d), total_entries |
| `mpc_modbus_write_log` | entry count | entries, rogue_write_count, total_writes |

### New Service
- `victron_mpc_battery_optimizer.record_feedback` — structured agree/disagree/override logging

### Security
- Pre-commit hook (`.githooks/pre-commit`) scans for JWT tokens, OpenRouter keys
- `.gitignore` updated with secrets section

## Test plan
- [x] 604 tests pass, 36 skipped (pre-existing API key skips)
- [x] 111 new tests across 3 test files
- [x] Existing test compatibility verified (test_modbus_health.py updated)
- [ ] Deploy to Pi and verify sensors appear in HA
- [ ] Test `record_feedback` service via Developer Tools
- [ ] Verify governance dashboard reads sensor attributes correctly

Closes #57, #61, #60, #65, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)